### PR TITLE
First pull request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.egg-info
+*.pyc
+node_modules
+.coverage
+bouncer/static/scripts/bundle.js
+.cache

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,6 @@
+javascript:
+  config_file: .jshintrc
+  ignore_file: .jshintignore
+jscs:
+  enabled: true
+  config_file: .jscsrc

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,23 @@
+{
+  "preset": "google",
+  "requireSemicolons": true,
+
+  "excludeFiles": [
+    "node_modules/**",
+  ],
+  "maxErrors": 10,
+  "disallowSpacesInAnonymousFunctionExpression": null,
+  "disallowSpacesInFunctionDeclaration": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInFunctionExpression": null,
+  "disallowSpacesInNamedFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "requireSpacesInFunctionDeclaration": null,
+  "requireSpacesInFunctionExpression": null,
+  "requireSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningRoundBrace": true,
+    "beforeOpeningCurlyBrace": true
+  }
+}

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,33 @@
+{
+  "bitwise": true,
+  "curly": true,
+  "eqeqeq": true,
+  "forin": true,
+  "freeze": true,
+  "latedef": "nofunc",
+  "maxcomplexity": 10,
+  "strict": "global",
+  "undef": true,
+  "unused": true,
+  "globals": {
+    "chrome": false,
+    "chai": false,
+    "sinon": false,
+    "JSON": false
+  },
+  "browser": true,
+  "browserify": true,
+  "mocha": true,
+  "phantom": true,
+  "predef": [
+    "assert",
+    "after",
+    "afterEach",
+    "before",
+    "beforeEach",
+    "describe",
+    "it",
+    "require",
+    "sinon"
+  ]
+}

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,43 @@
+output-format: grouped
+strictness: veryhigh
+doc-warnings: true
+max-line-length: 79
+pep8:
+  full: true
+pylint:
+  enable:
+    - relative-import
+  disable:
+    - line-too-long  # PEP8 checks this and doesn't complain about
+                     # unavoidable long lines (such as URLs).
+    - R0903  # Too few public methods
+    - W0142  # Used * or ** magic
+  options:
+    # Some good names that pylint would otherwise reject:
+    #
+    # - _: placeholder
+    # - i,j,k: counters
+    # - k,v: dict iteration
+    # - db,fn: common abbreviations
+    # - fp: python idiom for file handles
+    #
+    # Some good "constant" names that pylint would otherwise reject:
+    #
+    # - log: common in "log = logging.getLogger(__name__)" pattern
+    # - parser: common in modules that use argparse
+    # - id: Commonly used as a class attribute / database column name in
+    #       sqlalchemy model classes. Note that if you use id as the name of
+    #       a local variable or parameter, pylint will still complain that
+    #       you're shadowing the builtin.
+    #
+    good-names: _,i,j,k,v,e,db,fn,fp,log,parser,id
+pep257:
+  disable:
+    - D100  # Missing docstring in public module
+    - D101  # Missing docstring in public class
+    - D102  # Missing docstring in public method
+    - D103  # Missing docstring in public function
+pyroma:
+  run: true
+ignore-patterns:
+  - '.*\.egg'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+language:
+  - python
+python:
+  - "3.5"
+install:
+  - make deps
+  - pip install coveralls
+script:
+  - make test
+after_success:
+  - coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,4 @@
+0.0.1
+=====
+
+- First release, working proof of concept.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,1 @@
+For now, see the `hypothesis/h contributing guide <https://github.com/hypothesis/h/blob/master/CONTRIBUTING.rst>`_.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM frolvlad/alpine-python3
+MAINTAINER Hypothes.is Project and contributors
+
+# Install system build and runtime dependencies.
+RUN apk add --update \
+    nodejs \
+  && rm -rf /var/cache/apk/*
+
+# Create the bouncer user, group, home directory and package directory.
+RUN addgroup -S bouncer \
+  && adduser -S -G bouncer -h /var/lib/bouncer bouncer
+WORKDIR /var/lib/bouncer
+
+# Copy packaging
+COPY README.rst package.json setup.* ./
+
+# Install application dependencies.
+RUN npm install --production \
+  && pip install --no-cache-dir -e . \
+  && npm cache clean
+
+# Copy the rest of the application files
+COPY bouncer ./bouncer/
+
+# Persist the static directory.
+VOLUME ["/var/lib/bouncer/bouncer/static"]
+
+# Start the web server by default
+USER bouncer
+CMD ["gunicorn", "bouncer:app()"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2016 Hypothes.is Project and contributors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+deps:
+	pip install --upgrade pip
+	pip install --upgrade wheel
+	pip install -e .[dev]
+	npm install
+
+dev:
+	PYRAMID_RELOAD_TEMPLATES=1 gunicorn --reload "bouncer:app()"
+
+docker:
+	docker build -t hypothesis/bouncer .
+
+test:
+	py.test --cov=bouncer bouncer
+	./node_modules/karma/bin/karma start karma.config.js

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,71 @@
+.. image:: https://travis-ci.org/hypothesis/bouncer.svg?branch=master
+   :target: https://travis-ci.org/hypothesis/bouncer
+   :alt: Build Status
+
+
+Hypothesis Direct-Link Bouncer Service
+======================================
+
+Production Deployment
+---------------------
+
+Requirements:
+
+* `Docker <https://www.docker.com/>`_
+* `Git <https://git-scm.com/>`_
+* `Make <https://www.gnu.org/software/make/>`_
+
+Build the ``hypothesis/bouncer`` Docker image and run bouncer in a Docker
+container:
+
+.. code-block:: bash
+
+   git clone https://github.com/hypothesis/bouncer.git
+   cd bouncer
+   make docker
+   docker run --net host -p 8000:8000 hypothesis/bouncer
+
+
+Development
+-----------
+
+Requirements:
+
+* `Git <https://git-scm.com/>`_
+* `Make <https://www.gnu.org/software/make/>`_
+* `Python 3.5 <https://www.python.org/>`_
+* `Virtualenv <https://virtualenv.readthedocs.org/>`_
+
+Install:
+
+.. code-block:: bash
+
+   git clone https://github.com/hypothesis/bouncer.git
+   cd bouncer
+   virtualenv -p python3.5 .
+   . bin/activate
+   make deps
+
+Run the tests:
+
+.. code-block:: bash
+
+   make test
+
+To debug the JavaScript tests in a browser, run:
+
+.. code-block:: bash
+
+   ./node_modules/karma/bin/karma start --no-single-rin
+
+and open http://localhost:9876/ in your browser.
+
+To run a dev instance on port 8000:
+
+.. code-block:: bash
+
+   export CHROME_EXTENSION_ID=<id_of_your_local_dev_build_of_the_hypothesis_chrome_extension>
+   make dev
+
+Other environment variables can be used to change other settings, see
+`__init__.py <bouncer/__init__.py>`_.

--- a/bouncer/__init__.py
+++ b/bouncer/__init__.py
@@ -1,0 +1,43 @@
+import os
+
+import pyramid.config
+
+
+def settings():
+    """
+    Return the app's configuration settings as a dict.
+
+    Settings are read from environment variables and fall back to hardcoded
+    defaults if those variables aren't defined.
+
+    """
+    via_base_url = os.environ.get("VIA_BASE_URL", "https://via.hypothes.is")
+    if via_base_url.endswith("/"):
+        via_base_url = via_base_url[:-1]
+
+    return {
+        "chrome_extension_id": os.environ.get(
+            "CHROME_EXTENSION_ID",
+            "bjfhmglciegochdpefhhlphglcehbmek"),
+        "elasticsearch_host": os.environ.get("ELASTICSEARCH_HOST",
+                                             "localhost"),
+        "elasticsearch_index": os.environ.get("ELASTICSEARCH_INDEX",
+                                              "annotator"),
+        "elasticsearch_port": os.environ.get("ELASTICSEARCH_PORT",
+                                             "9200"),
+        "hypothesis_url": os.environ.get("HYPOTHESIS_URL",
+                                         "https://hypothes.is"),
+        "via_base_url": via_base_url,
+    }
+
+
+def app():
+    """Configure and return the WSGI app."""
+    config = pyramid.config.Configurator(settings=settings())
+    config.add_static_view(name="static", path="static")
+    config.include("pyramid_jinja2")
+    config.registry.settings["jinja2.filters"] = {
+        "static_url": "pyramid_jinja2.filters:static_url_filter"
+    }
+    config.include("bouncer.views")
+    return config.make_wsgi_app()

--- a/bouncer/scripts/redirect.js
+++ b/bouncer/scripts/redirect.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/** The ID of the Chrome extension we want to talk to. */
+var EDITOR_EXTENSION_ID = 'oldbkmekfdjiffgkconlamcngmkioffd';
+
+/** Return the settings object that the server injected into the page. */
+function getSettings(document) {
+  return JSON.parse(
+    document.querySelector('script.js-bouncer-settings').textContent);
+}
+
+/** Navigate the browser to the given URL. */
+function navigateTo(url) {
+  window.location = url;
+}
+
+/** Navigate the browser to the requested annotation.
+ *
+ * If the browser is Chrome and our Chrome extension is installed then
+ * navigate to the annotation's direct link for the Chrome extension.
+ * If the Chrome extension isn't installed or the browser isn't Chrome then
+ * navigate to the annotation's Via direct link.
+ *
+ */
+function redirect(navigateToFn) {
+  // Use the test navigateTo() function if one was passed in, the real
+  // navigateTo() otherwise.
+  navigateTo = navigateToFn || navigateTo;
+
+  var settings = getSettings(document);
+
+  if (window.chrome && chrome.runtime && chrome.runtime.sendMessage) {
+    // The user is using Chrome, redirect them to our Chrome extension if they
+    // have it installed, via otherwise.
+    chrome.runtime.sendMessage(
+      EDITOR_EXTENSION_ID,
+      {type: 'ping'},
+      function (response) {
+        var url;
+        if (response) {
+          // The user has our Chrome extension installed :)
+          url = settings.extensionUrl;
+        } else {
+          // The user doesn't have our Chrome extension installed :(
+          url = settings.viaUrl;
+        }
+        navigateTo(url);
+      }
+    );
+  } else {
+    // The user isn't using Chrome, just redirect them to Via.
+    navigateTo(settings.viaUrl);
+  }
+}
+
+if (typeof module === 'object') {
+  // Browserify is present, this file must be being run by the tests.
+  module.exports = redirect;
+} else {
+  // Browserify is not present, this file must be being run in development or
+  // production.
+  redirect();
+}

--- a/bouncer/scripts/test/redirect-test.js
+++ b/bouncer/scripts/test/redirect-test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var redirect = require('../redirect.js');
+
+describe('redirect()', function () {
+  beforeEach(function () {
+    window.chrome = undefined;
+    window.document.querySelector = function () {
+      return {
+        textContent: JSON.stringify({
+          extensionUrl: 'http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q',
+          viaUrl: 'https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q',
+        })
+      };
+    };
+  });
+
+  it('redirects to Via if not Chrome', function () {
+    window.chrome = undefined;  // The user isn't using Chrome.
+    var navigateTo = sinon.stub();
+
+    redirect(navigateTo);
+
+    assert.equal(navigateTo.calledOnce, true);
+    assert.equal(
+      navigateTo.calledWithExactly('https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q'),
+      true);
+  });
+
+  it('redirects to Via if window.chrome but no chrome.runtime', function () {
+    // Some browsers define window.chrome but not chrome.runtime.
+    window.chrome = {}
+    var navigateTo = sinon.stub();
+
+    redirect(navigateTo);
+
+    assert.equal(navigateTo.calledOnce, true);
+    assert.equal(
+      navigateTo.calledWithExactly('https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q'),
+      true);
+  });
+
+  it('redirects to Via if window.chrome but no sendMessage', function () {
+    // Some browsers might window.chrome but not chrome.runtime.sendMessage.
+    window.chrome = {runtime: {}}
+    var navigateTo = sinon.stub();
+
+    redirect(navigateTo);
+
+    assert.equal(navigateTo.calledOnce, true);
+    assert.equal(
+      navigateTo.calledWithExactly('https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q'),
+      true);
+  });
+
+  it('redirects to Via if Chrome but no extension', function () {
+    window.chrome = {
+      runtime: {
+        sendMessage: function (id, message, callbackFunction) {
+          callbackFunction(null);
+        }
+      }
+    };
+    var navigateTo = sinon.stub();
+
+    redirect(navigateTo);
+
+    assert.equal(navigateTo.calledOnce, true);
+    assert.equal(
+      navigateTo.calledWithExactly('https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q'),
+      true);
+  });
+
+  it('redirects to Chrome extension if installed', function () {
+    window.chrome = {
+      runtime: {
+        sendMessage: function (id, message, callbackFunction) {
+          callbackFunction('Hey!');
+        }
+      }
+    };
+    var navigateTo = sinon.stub();
+
+    redirect(navigateTo);
+
+    assert.equal(navigateTo.calledOnce, true);
+    assert.equal(
+      navigateTo.calledWithExactly('http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q'),
+      true);
+  });
+});

--- a/bouncer/static/images/hypothesis-icon.svg
+++ b/bouncer/static/images/hypothesis-icon.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="24px" height="28px" viewBox="0 0 24 28" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.5.2 (25235) - http://www.bohemiancoding.com/sketch -->
+    <title>Rectangle 2 Copy 18</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <path d="M0,2.00494659 C0,0.897645164 0.897026226,0 2.00494659,0 L21.9950534,0 C23.1023548,0 24,0.897026226 24,2.00494659 L24,21.9950534 C24,23.1023548 23.1029738,24 21.9950534,24 L2.00494659,24 C0.897645164,24 0,23.1029738 0,21.9950534 L0,2.00494659 Z M9,24 L12,28 L15,24 L9,24 Z M7.00811294,4 L4,4 L4,20 L7.00811294,20 L7.00811294,15.0028975 C7.00811294,12.004636 8.16824717,12.0097227 9,12 C10,12.0072451 11.0189302,12.0606714 11.0189302,14.003477 L11.0189302,20 L14.0270431,20 L14.0270431,13.1087862 C14.0270433,10 12,9.00309038 10,9.00309064 C8.01081726,9.00309091 8,9.00309086 7.00811294,11.0019317 L7.00811294,4 Z M19,19.9869002 C20.1045695,19.9869002 21,19.0944022 21,17.9934501 C21,16.892498 20.1045695,16 19,16 C17.8954305,16 17,16.892498 17,17.9934501 C17,19.0944022 17.8954305,19.9869002 19,19.9869002 Z" id="Rectangle-2-Copy-18" fill="#A6A6A6" sketch:type="MSShapeGroup"></path>
+    </g>
+</svg>

--- a/bouncer/static/images/sad-annotation.svg
+++ b/bouncer/static/images/sad-annotation.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="83.25"
+   height="77"
+   viewBox="0 0 83.250001 77"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="sad-annotation.svg">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Slice 1</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1136"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="14.511061"
+     inkscape:cx="40.492557"
+     inkscape:cy="26.433356"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">Slice 1</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+  <g
+     id="g4190"
+     transform="matrix(2.7499752,0,0,2.7499752,-94.498774,87.999238)">
+    <path
+       id="Active-Browser-Action-2"
+       d="m 40.775628,-31.99996 c -3.383384,0 -6.17429,2.743483 -6.233678,6.128566 l -0.177487,10.116796 c -0.05938,3.384714 2.636624,6.170658 6.021232,6.220446 0,0 3.294847,0.05556 3.422692,0.03896 3.054071,0.501576 4.553784,5.509558 5.626192,5.495351 1.17924,-0.01427 2.467031,-5.54251 5.757035,-5.626193 2.038215,0.04573 3.033319,0.02027 3.033319,0.02027 3.383074,-0.01119 6.17373,-2.76375 6.233117,-6.148833 l 0.177488,-10.116796 c 0.05938,-3.384713 -2.636179,-6.128566 -6.018641,-6.128566 l -17.841269,0 0,0 z m 1.527685,3.009359 c -2.538406,0 -4.633292,2.054603 -4.679175,4.595603 l -0.124636,6.902321 c -0.04583,2.538081 1.974395,4.627187 4.511683,4.664669 0,0 2.847145,0.04737 2.948104,0.03426 2.411799,0.396104 3.929323,3.549019 4.484978,3.560239 0.555655,0.01122 1.906237,-3.597481 4.504351,-3.663567 1.609577,0.03612 4.168132,0.01369 4.168132,0.01369 1.692566,-0.0076 3.089438,-1.385812 3.120006,-3.078638 l 0.152275,-8.432973 c 0.04583,-2.538084 -1.974083,-4.595605 -4.513209,-4.595605 l -14.572509,0 0,0 z"
+       inkscape:connector-curvature="0"
+       style="fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" />
+    <ellipse
+       ry="2.093467"
+       rx="1.5701002"
+       cy="-23.364407"
+       cx="44.200912"
+       id="Oval-1"
+       style="fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" />
+    <path
+       id="Oval-2"
+       d="m 54.668247,-21.270942 c 0.867142,0 1.5701,-0.937277 1.5701,-2.093467 0,-1.15619 -0.702958,-2.093467 -1.5701,-2.093467 -0.867143,0 -1.5701,0.937277 -1.5701,2.093467 0,1.15619 0.702957,2.093467 1.5701,2.093467 l 0,0 z"
+       inkscape:connector-curvature="0"
+       style="fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" />
+    <path
+       id="path18"
+       d="m 49.434579,-16.853951 c 0.841137,0.03915 1.314276,0.227372 1.654528,0.330742 0.337431,0.174845 0.630819,0.445402 0.835266,0.799515 0.226995,0.393166 0.728087,0.528826 1.119221,0.303005 0.391134,-0.225822 0.524196,-0.72761 0.297201,-1.120776 -0.812015,-1.406451 -2.381656,-1.981801 -3.906216,-1.981801 -1.57713,0 -3.0942,0.57535 -3.906215,1.981801 -0.226995,0.393166 -0.09393,0.894954 0.297201,1.120776 0.391134,0.225821 0.892226,0.09016 1.11922,-0.303005 0.204448,-0.354113 0.497835,-0.62467 0.835267,-0.799515 0,0 0.865962,-0.291589 1.654527,-0.330742 l 0,0 z"
+       inkscape:connector-curvature="0"
+       style="fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" />
+  </g>
+</svg>

--- a/bouncer/static/styles/bouncer.css
+++ b/bouncer/static/styles/bouncer.css
@@ -1,0 +1,56 @@
+body {
+  color: #7a7a7a;
+  font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-size: 14px;
+}
+
+p {
+  margin: 0;
+}
+
+/* Vertically and horizontally center a block such as a <div>. */
+.center {
+  display: block;
+  left: 50%;
+  position: absolute;
+  text-align: center;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.spinner__icon {
+  height: 28px;
+  padding-top: 2px;
+  width: 24px;
+}
+.spinner__text {
+  margin-top: 116px;
+}
+.spinner__stationary-ring {
+  border: 3px solid #dbdbdb;
+  border-radius: 50%;
+  height: 74px;
+  width: 74px;
+}
+.spinner__moving-ring {
+  animation-duration: 1s;
+  animation-fill-mode: forwards;
+  animation-iteration-count: infinite;
+  animation-name: moving-ring;
+  animation-timing-function: linear;
+  border-left: 3px solid #a6a6a6;
+  border-radius: 100% 0 0 0;
+  border-top: 3px solid #a6a6a6;
+  height: 37px;
+  transform: translate(-3px, -3px);
+  transform-origin: bottom right;
+  width: 37px;
+}
+@keyframes moving-ring {
+  from {
+    transform: translate(-3px, -3px) rotate(0deg);
+  }
+  to {
+    transform: translate(-3px, -3px) rotate(359deg);
+  }
+}

--- a/bouncer/templates/annotation.html.jinja2
+++ b/bouncer/templates/annotation.html.jinja2
@@ -1,0 +1,25 @@
+{% extends "templates/base.html.jinja2" %}
+
+{% set title = _("Hypothesis: Redirecting you&hellip;") %}
+
+{% block content %}
+  <div class="center spinner__stationary-ring">
+    <img alt="Redirecting"
+          class="center spinner__icon"
+          height="24"
+          src="{{'bouncer:static/images/hypothesis-icon.svg'|static_url}}"
+          width="28">
+    <div class="spinner__moving-ring"></div>
+  </div>
+  <p class="spinner__text">{% trans %}Redirecting{% endtrans %}</p>
+{% endblock %}
+
+{% block scripts %}
+  <!-- Render a configuration object for the redirect.js to pick up. -->
+  <script class="js-bouncer-settings" type="application/json">
+    {{ data | safe }}
+  </script>
+  <script>
+    {% include '../scripts/redirect.js' %}
+  </script>
+{% endblock %}

--- a/bouncer/templates/base.html.jinja2
+++ b/bouncer/templates/base.html.jinja2
@@ -1,0 +1,16 @@
+<!doctype html>
+  <html lang=en>
+  <head>
+    <meta charset=utf-8>
+    <title>{{ title|safe }}</title>
+    <link rel="stylesheet"
+          type="text/css"
+          href="{{'bouncer:static/styles/bouncer.css'|static_url}}">
+  </head>
+  <body>
+    <div class="center">
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+  {% block scripts %}{% endblock %}
+</html>

--- a/bouncer/templates/notfound.html.jinja2
+++ b/bouncer/templates/notfound.html.jinja2
@@ -1,0 +1,12 @@
+{% extends "templates/base.html.jinja2" %}
+
+{% set title = _("Hypothesis: Not found :(") %}
+
+{% block content %}
+  <img src="{{'bouncer:static/images/sad-annotation.svg'|static_url}}">
+  <p>
+    {% trans %}
+      Not found
+    {% endtrans %}
+  </p>
+{% endblock %}

--- a/bouncer/test/views_test.py
+++ b/bouncer/test/views_test.py
@@ -1,0 +1,83 @@
+import json
+
+from elasticsearch import exceptions
+import mock
+from pyramid import httpexceptions
+from pyramid import testing
+import pytest
+
+from bouncer import views
+
+
+@mock.patch("bouncer.views.elasticsearch")
+class TestAnnotationController(object):
+
+    def test_annotation_inits_elasticsearch_client(self, elasticsearch):
+        views.AnnotationController(mock_request()).annotation()
+
+        elasticsearch.Elasticsearch.assert_called_once_with(
+            host="http://localhost/", port="9200"
+        )
+
+    def test_annotation_calls_get(self, elasticsearch):
+        views.AnnotationController(mock_request()).annotation()
+
+        elasticsearch.Elasticsearch.return_value.get.assert_called_once_with(
+            index="annotator",
+            doc_type="annotation",
+            id="AVLlVTs1f9G3pW-EYc6q"
+        )
+
+    def test_annotation_raises_HTTPNotFound_if_get_raises_NotFoundError(
+            self, elasticsearch):
+        elasticsearch.Elasticsearch.return_value.get.side_effect = (
+            exceptions.NotFoundError)
+        with pytest.raises(httpexceptions.HTTPNotFound):
+            views.AnnotationController(mock_request()).annotation()
+
+    def test_annotation_returns_via_url(self, elasticsearch):
+        elasticsearch.Elasticsearch.return_value.get.return_value = {
+            "_id": "AVLlVTs1f9G3pW-EYc6q",
+            "_source": {"uri": "http://www.example.com/example.html"}
+        }
+        template_data = views.AnnotationController(mock_request()).annotation()
+
+        data = json.loads(template_data["data"])
+        assert data["viaUrl"] == (
+                "https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
+
+    def test_annotation_returns_extension_url(self, elasticsearch):
+        elasticsearch.Elasticsearch.return_value.get.return_value = {
+            "_id": "AVLlVTs1f9G3pW-EYc6q",
+            "_source": {"uri": "http://www.example.com/example.html"}
+        }
+        template_data = views.AnnotationController(mock_request()).annotation()
+
+        data = json.loads(template_data["data"])
+        assert data["extensionUrl"] == (
+                "http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
+
+
+def test_index_redirects_to_hypothesis():
+    with pytest.raises(httpexceptions.HTTPFound) as exc:
+        views.index(mock_request())
+    assert exc.value.location == "https://hypothes.is"
+
+
+def test_notfound_404s():
+    request = testing.DummyRequest()
+
+    views.notfound(request)
+
+    assert request.response.status_int == 404
+
+
+def mock_request():
+    request = testing.DummyRequest()
+    request.registry.settings = {"elasticsearch_host": "http://localhost/",
+                                 "elasticsearch_port": "9200",
+                                 "elasticsearch_index": "annotator",
+                                 "hypothesis_url": "https://hypothes.is",
+                                 "via_base_url": "https://via.hypothes.is"}
+    request.matchdict = {"id": "AVLlVTs1f9G3pW-EYc6q"}
+    return request

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -1,0 +1,78 @@
+import json
+
+import elasticsearch
+from elasticsearch import exceptions
+from pyramid import httpexceptions
+from pyramid import view
+
+
+@view.view_defaults(renderer="bouncer:templates/annotation.html.jinja2")
+class AnnotationController(object):
+
+    def __init__(self, request):
+        self.request = request
+
+    @view.view_config(route_name="annotation_with_url")
+    @view.view_config(route_name="annotation_without_url")
+    def annotation(self):
+
+        settings = self.request.registry.settings
+
+        try:
+            document = elasticsearch_client(settings).get(
+                index=settings["elasticsearch_index"],
+                doc_type="annotation",
+                id=self.request.matchdict["id"])
+        except exceptions.NotFoundError:
+            raise httpexceptions.HTTPNotFound()
+
+        annotation_id = document["_id"]
+        document_uri = document["_source"]["uri"]
+
+        # FIXME: Strip query params, anchors from document_uri here?
+
+        via_url = "{via_base_url}/{uri}#annotations:{id}".format(
+            via_base_url=settings["via_base_url"],
+            uri=document_uri,
+            id=annotation_id)
+
+        extension_url = "{uri}#annotations:{id}".format(
+            uri=document_uri, id=annotation_id)
+
+        return {
+            "data": json.dumps({
+                # Warning: variable names change from python_style to
+                # javaScriptStyle here!
+                "viaUrl": via_url,
+                "extensionUrl": extension_url,
+            })
+        }
+
+
+def elasticsearch_client(settings):
+    return elasticsearch.Elasticsearch(
+        host=settings["elasticsearch_host"],
+        port=settings["elasticsearch_port"],
+    )
+
+
+@view.view_config(renderer="bouncer:templates/index.html.jinja2",
+                  route_name="index")
+def index(request):
+    raise httpexceptions.HTTPFound(
+        location=request.registry.settings["hypothesis_url"])
+
+
+@view.notfound_view_config(
+    append_slash=True,
+    renderer='bouncer:templates/notfound.html.jinja2')
+def notfound(request):
+    request.response.status_int = 404
+    return {}
+
+
+def includeme(config):
+    config.add_route("index", "/")
+    config.add_route("annotation_with_url", "/{id}/*url")
+    config.add_route("annotation_without_url", "/{id}/")
+    config.scan(__name__)

--- a/karma.config.js
+++ b/karma.config.js
@@ -1,0 +1,23 @@
+module.exports = function (config) {
+  config.set({
+    browserify: {
+      debug: true
+    },
+    basePath: '',
+    frameworks: ['browserify', 'chai', 'mocha', 'sinon'],
+    files: [
+      'bouncer/**/*-test.js'
+    ],
+    preprocessors: {
+      '**/*-test.js': ['browserify']
+    },
+    reporters: ['progress'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: false,
+    browsers: ['PhantomJS2'],
+    singleRun: true,
+    concurrency: Infinity
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "devDependencies": {
+    "browserify": "^13.0.0",
+    "chai": "^3.5.0",
+    "jscs": "^1.13.1",
+    "jshint": "^2.9.1",
+    "karma": "^0.13.21",
+    "karma-browserify": "^4.4.2",
+    "karma-chai": "^0.1.0",
+    "karma-mocha": "^0.2.2",
+    "karma-phantomjs2-launcher": "^0.5.0",
+    "karma-sinon": "^1.0.4",
+    "mocha": "^2.4.5",
+    "sinon": "^1.17.3"
+  },
+  "license": "BSD-2-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hypothesis/bouncer.git"
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,46 @@
+from setuptools import setup, find_packages
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file.
+with open(path.join(here, "README.rst"), encoding="utf-8") as f:
+    long_description = f.read()
+
+DEV_EXTRAS = [
+    "coverage",
+    "mock",
+    "prospector",
+    "pytest",
+    "pytest-cov",
+]
+setup(
+    author="Hypothesis Project & Contributors",
+    author_email="contact@hypothes.is",
+    description="Hypothesis direct-link bouncer service",
+    keywords="annotation web javascript",
+    license="Simplified (2-Clause) BSD License",
+    long_description=long_description,
+    name="bouncer",
+    url="https://github.com/hypothesis/bouncer",
+    version="0.0.1",  # PEP440-compliant version number.
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: BSD License",  # Should match "license"
+                                                   # above.
+        'Programming Language :: Python :: 2.7',
+    ],
+
+    packages=find_packages(exclude=[]),
+
+    install_requires=[
+        "elasticsearch>=2.0.0,<3.0.0",
+        "gunicorn==19.4.5",
+        "pyramid==1.6.1",
+        "pyramid-jinja2==2.6.2",
+    ],
+
+    extras_require={
+        'dev': DEV_EXTRAS,
+    },
+)


### PR DESCRIPTION
Working proof of concept, given suitable changes to your local Chrome extension (and hacking this repo's code to include your extension's ID instead of mine), this will redirect you to the extension or (if you disable the extension) to Via.

- [x] Read config settings from env vars (Chrome extension ID, Elasticsearch URL...)
- [x] Add linter configs
- [x] Write Python tests
- [x] Write JavaScript tests
- [x] Add Travis CI
- [ ] Add Coveralls
- [ ] Add Landscape
- [x] Add Hound
- [x] Write a CONTRIBUTING.rst
- [x] Add the CSS redirecting animation
- [x] Get a better Hypothesis icon for the redirecting page (SVG would be nice)
- [x] Add a jinja scripts block in the right place
- [ ] Handle query params, anchors in document URI
- [x] Run in Python 3 not 2.7
- [ ] Test it on a wide range of annotations, make sure that the code for extracting the annotated URI always works
- [x] Alphabetize CSS
- [x] Docker support for production deployment
- [x] <del>Include font</del>
- [ ] Issue with image not showing (if JavaScript loads and executes before image loads?)
- [x] Fix browserify / JavaScript assets issue