### PR TITLE
Report some initial stats to statsd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ VOLUME ["/var/lib/bouncer/bouncer/static"]
 
 # Start the web server by default
 USER bouncer
-CMD ["gunicorn", "bouncer:app()"]
+CMD ["gunicorn", "--config", "gunicorn.conf.py", "bouncer:app()"]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ deps:
 	npm install
 
 dev:
-	PYRAMID_RELOAD_TEMPLATES=1 gunicorn --reload "bouncer:app()"
+	PYRAMID_RELOAD_TEMPLATES=1 gunicorn --config gunicorn.conf.py --reload "bouncer:app()"
 
 docker:
 	docker build -t hypothesis/bouncer .

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,55 @@
 Hypothesis Direct-Link Bouncer Service
 ======================================
 
+Configuration
+-------------
+
+You can set various environment variables to configure bouncer before running
+it in production or development:
+
+CHROME_EXTENSION_ID
+  The ID of the Hypothesis Chrome extension that bouncer will communicate with
+  (default: the ID of the `official Hypothesis Chrome extension <https://chrome.google.com/webstore/detail/hypothesis-web-pdf-annota/bjfhmglciegochdpefhhlphglcehbmek>`_)
+
+ELASTICSEARCH_HOST
+  The hostname of the Elasticsearch server that bouncer will read annotations
+  from (default: localhost)
+
+ELASTICSEARCH_INDEX
+  The name of the Elasticsearch index that bouncer will read annotations
+  from (default: annotator)
+
+ELASTICSEARCH_PORT
+  The port of the Elasticsearch server that bouncer will read annotations
+  from (default: 9200)
+
+HYPOTHESIS_URL
+  The URL of the Hypothesis front page that requests to bouncer's front page
+  will be redirected to (default: https://hypothes.is)
+
+STATSD_HOST
+  The host of the statsd server that bouncer will report stats to
+  (default: localhost)
+
+STATSD_PORT
+  The port of the statsd server that bouncer will report stats to
+  (default: 8125)
+
+STATSD_PREFIX
+  A string prefix that bouncer will prepend to all metric paths reported to
+  statsd (default: none).
+  We recommend ``export STATSD_PREFIX=bouncer`` so that all bouncer's metrics
+  will start with ``bouncer``.
+
+STATSD_MAXUDPSIZE
+  The maximum packet size that statsd will use (default: 512)
+
+VIA_BASE_URL
+  The base URL of the Via service that bouncer will redirect users to if they
+  don't have the Hypothesis Chrome extension installed
+  (default: https://via.hypothes.is)
+
+
 Production Deployment
 ---------------------
 
@@ -72,6 +121,3 @@ To run a dev instance on port 8000:
 
    export CHROME_EXTENSION_ID=<id_of_your_local_dev_build_of_the_hypothesis_chrome_extension>
    make dev
-
-Other environment variables can be used to change other settings, see
-`__init__.py <bouncer/__init__.py>`_.

--- a/README.rst
+++ b/README.rst
@@ -52,9 +52,6 @@ STATSD_PREFIX
   We recommend ``export STATSD_PREFIX=bouncer`` so that all bouncer's metrics
   will start with ``bouncer``.
 
-STATSD_MAXUDPSIZE
-  The maximum packet size that statsd will use (default: 512)
-
 VIA_BASE_URL
   The base URL of the Via service that bouncer will redirect users to if they
   don't have the Hypothesis Chrome extension installed

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,7 @@
+import os
+
+statsd_host = "{host}:{port}".format(
+    host=os.environ.get("STATSD_HOST", "localhost"),
+    port=os.environ.get("STATSD_PORT", "8125"))
+
+statsd_prefix = os.environ.get("STATSD_PREFIX", "")

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "gunicorn==19.4.5",
         "pyramid==1.6.1",
         "pyramid-jinja2==2.6.2",
+        "statsd==3.2.1",
     ],
 
     extras_require={


### PR DESCRIPTION
Statsd is configured using environment variables documented in the README.

Each view callable reports its result to statsd using a naming convention based on [this advice](https://matt.aimonetti.net/posts/2013/06/26/practical-guide-to-graphite-monitoring/), e.g. "views.annotation.404.annotation_not_found", "views.annotation.200".

Separately a `NewRequest` subscriber increments a "requests" counter that simply counts the number of incoming requests regardless of which view (if any) gets called and what its outcome is.