### PR TITLE
Report Python exceptions to Sentry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,10 @@ HYPOTHESIS_URL
   The URL of the Hypothesis front page that requests to bouncer's front page
   will be redirected to (default: https://hypothes.is)
 
+SENTRY_DSN
+    The DSN (Data Source Name) that bouncer will use to report crashes to
+    `Sentry <https://getsentry.com/>`_
+
 STATSD_HOST
   The host of the statsd server that bouncer will report stats to
   (default: localhost)

--- a/bouncer/__about__.py
+++ b/bouncer/__about__.py
@@ -1,0 +1,6 @@
+"""Metadata about bouncer shared between setup.py and bouncer code."""
+
+__all__ = ["__version__"]
+
+
+__version__ = "0.0.1"  # PEP440-compliant version number.

--- a/bouncer/__init__.py
+++ b/bouncer/__init__.py
@@ -40,4 +40,5 @@ def app():
         "static_url": "pyramid_jinja2.filters:static_url_filter"
     }
     config.include("bouncer.views")
+    config.include("bouncer.sentry")
     return config.make_wsgi_app()

--- a/bouncer/sentry.py
+++ b/bouncer/sentry.py
@@ -1,0 +1,53 @@
+"""Report exceptions to Sentry/Raven."""
+from pyramid import tweens
+import raven
+
+from bouncer import __about__
+
+
+#: The Raven client object that's used to send reports to Sentry.
+#: This object is created once per app and re-used across requests.
+#:
+#: This should be accessed via request.raven rather than directly, because
+#: get_raven_client() below adds per-request context to the client.
+raven_client = raven.Client(release=__about__.__version__)
+
+
+def raven_tween_factory(handler, _):
+    """Return a tween that reports uncaught exceptions to Sentry."""
+    def raven_tween(request):
+        """Report uncaught exceptions to Sentry."""
+        try:
+            return handler(request)
+        except:
+            request.raven.captureException()
+            raise
+
+    return raven_tween
+
+
+def get_raven_client(request):
+    """Add per-request context to raven_client and return it."""
+    # Add request-specific context to the Raven client.
+    raven_client.http_context({
+        "url": request.url,
+        "method": request.method,
+    })
+
+    # Clear the request-specific context at the end of each request so that it
+    # isn't carried over to the next request (the same raven_client object is
+    # used across requests).
+    request.add_finished_callback(
+        lambda request: raven_client.context.clear())
+
+    return raven_client
+
+
+def includeme(config):
+    config.add_request_method(
+        get_raven_client,
+        name="raven",
+        reify=True)
+    config.add_tween(
+        "bouncer.sentry.raven_tween_factory",
+        under=tweens.EXCVIEW)

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -67,7 +67,6 @@ def index(request):
 
 
 @view.notfound_view_config(
-    append_slash=True,
     renderer='bouncer:templates/notfound.html.jinja2')
 def notfound(request):
     request.response.status_int = 404
@@ -77,5 +76,5 @@ def notfound(request):
 def includeme(config):
     config.add_route("index", "/")
     config.add_route("annotation_with_url", "/{id}/*url")
-    config.add_route("annotation_without_url", "/{id}/")
+    config.add_route("annotation_without_url", "/{id}")
     config.scan(__name__)

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
+version = {}
+with open("bouncer/__about__.py") as fp:
+    exec(fp.read(), version)
+
 DEV_EXTRAS = [
     "coverage",
     "mock",
@@ -23,7 +27,7 @@ setup(
     long_description=long_description,
     name="bouncer",
     url="https://github.com/hypothesis/bouncer",
-    version="0.0.1",  # PEP440-compliant version number.
+    version=version["__version__"],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: BSD License",  # Should match "license"
@@ -38,6 +42,7 @@ setup(
         "gunicorn==19.4.5",
         "pyramid==1.6.1",
         "pyramid-jinja2==2.6.2",
+        "raven==5.10.2",
         "statsd==3.2.1",
     ],
 


### PR DESCRIPTION
Report Python exceptions to a Sentry project.

- Raven (the official Python client for Sentry) is added to the
  requirements in setup.py.

- The Sentry DSN (the URI that's needed to authenticate to Sentry) is
  read from the SENTRY_DSN environment variable like all other config
  settings in bouncer.

- bouncer/sentry.py is a new module that contains all the new
  Sentry/raven stuff.

  We add a raven client object configured with the SENTRY_DSN from the
  environment as request.raven, so that it can be accessed by our raven
  tween.

  Then we wrap the existing bouncer Pyramid app in a Pyramid tween that
  catches any exceptions, reports them to Sentry, then re-raises the
  exception.

  Any uncaught exceptions raised anywhere in the code, e.g. in a view
  callable, will be caught and reported to Sentry by this tween.