### PR TITLE
Add Sentry reporting of JavaScript crashes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,14 @@ HYPOTHESIS_URL
   will be redirected to (default: https://hypothes.is)
 
 SENTRY_DSN
-    The DSN (Data Source Name) that bouncer will use to report crashes to
-    `Sentry <https://getsentry.com/>`_
+    The DSN (Data Source Name) that bouncer's server-side code will use to
+    report crashes to `Sentry <https://getsentry.com/>`_
+
+SENTRY_JAVASCRIPT_DSN
+    The DSN (Data Source Name) that bouncer's client-side JavaScript code will
+    use to report crashes to `Sentry <https://getsentry.com/>`_.
+    This is different to SENTRY_DSN above - it doesn't include the secret key
+    part of the DSN.
 
 STATSD_HOST
   The host of the statsd server that bouncer will report stats to
@@ -112,7 +118,7 @@ To debug the JavaScript tests in a browser, run:
 
 .. code-block:: bash
 
-   ./node_modules/karma/bin/karma start --no-single-rin
+   ./node_modules/karma/bin/karma start --no-single-run
 
 and open http://localhost:9876/ in your browser.
 

--- a/bouncer/__init__.py
+++ b/bouncer/__init__.py
@@ -27,6 +27,7 @@ def settings():
                                              "9200"),
         "hypothesis_url": os.environ.get("HYPOTHESIS_URL",
                                          "https://hypothes.is"),
+        "sentry_javascript_dsn": os.environ.get("SENTRY_JAVASCRIPT_DSN"),
         "via_base_url": via_base_url,
     }
 

--- a/bouncer/scripts/redirect.js
+++ b/bouncer/scripts/redirect.js
@@ -9,6 +9,15 @@ function getSettings(document) {
     document.querySelector('script.js-bouncer-settings').textContent);
 }
 
+var SETTINGS = getSettings(document);
+
+/** Configure Raven to report any crashes to Sentry. */
+Raven.config(
+    SETTINGS.sentry_javascript_dsn,
+    {'release': SETTINGS.version}
+  ).install();
+
+
 /** Navigate the browser to the given URL. */
 function navigateTo(url) {
   window.location = url;
@@ -27,8 +36,6 @@ function redirect(navigateToFn) {
   // navigateTo() otherwise.
   navigateTo = navigateToFn || navigateTo;
 
-  var settings = getSettings(document);
-
   if (window.chrome && chrome.runtime && chrome.runtime.sendMessage) {
     // The user is using Chrome, redirect them to our Chrome extension if they
     // have it installed, via otherwise.
@@ -39,17 +46,17 @@ function redirect(navigateToFn) {
         var url;
         if (response) {
           // The user has our Chrome extension installed :)
-          url = settings.extensionUrl;
+          url = SETTINGS.extensionUrl;
         } else {
           // The user doesn't have our Chrome extension installed :(
-          url = settings.viaUrl;
+          url = SETTINGS.viaUrl;
         }
         navigateTo(url);
       }
     );
   } else {
     // The user isn't using Chrome, just redirect them to Via.
-    navigateTo(settings.viaUrl);
+    navigateTo(SETTINGS.viaUrl);
   }
 }
 

--- a/bouncer/templates/annotation.html.jinja2
+++ b/bouncer/templates/annotation.html.jinja2
@@ -15,6 +15,7 @@
 {% endblock %}
 
 {% block scripts %}
+  <script src="//cdn.ravenjs.com/2.1.0/raven.min.js"></script>
   <!-- Render a configuration object for the redirect.js to pick up. -->
   <script class="js-bouncer-settings" type="application/json">
     {{ data | safe }}

--- a/bouncer/test/views_test.py
+++ b/bouncer/test/views_test.py
@@ -77,6 +77,8 @@ def mock_request():
     request.registry.settings = {"elasticsearch_host": "http://localhost/",
                                  "elasticsearch_port": "9200",
                                  "elasticsearch_index": "annotator",
+                                 "sentry_dsn": "{PROTOCOL}://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PATH}{PROJECT_ID}",
+                                 "sentry_javascript_dsn": "{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}",
                                  "hypothesis_url": "https://hypothes.is",
                                  "via_base_url": "https://via.hypothes.is"}
     request.matchdict = {"id": "AVLlVTs1f9G3pW-EYc6q"}

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -6,6 +6,8 @@ from pyramid import httpexceptions
 from pyramid import view
 from statsd.defaults.env import statsd
 
+from bouncer import __about__
+
 
 @view.view_defaults(renderer="bouncer:templates/annotation.html.jinja2")
 class AnnotationController(object):
@@ -45,8 +47,11 @@ class AnnotationController(object):
             "data": json.dumps({
                 # Warning: variable names change from python_style to
                 # javaScriptStyle here!
-                "viaUrl": via_url,
                 "extensionUrl": extension_url,
+                "sentry_javascript_dsn":
+                    self.request.registry.settings["sentry_javascript_dsn"],
+                "version": __about__.__version__,
+                "viaUrl": via_url,
             })
         }
 


### PR DESCRIPTION
Add raven.min.js (Sentry's JavaScript client) to the annotation
redirector page (currently just using Sentry's CDN-hosted copy).

Add an additional environment variable SENTRY_JAVASCRIPT_DSN since the
Sentry DSN that the client-side JavaScript code uses is different to the
one that the server-side code uses (it doesn't contain the secret key
part because it isn't secure).

The server renders the SENTRY_JAVASCRIPT_DSN into the HTML along with
the rest of the settings.

The JavaScript code in redirect.js picks this up and uses it to
configure Raven, which automatically reports crashes to Sentry.

Also add the bouncer release version number to the settings object that
the server sends to the JavaScript so that JavaScript crash reports can
include the version number as Python ones do.