### PR TITLE
Do not crash on bad annotations

### DIFF
--- a/bouncer/test/util_test.py
+++ b/bouncer/test/util_test.py
@@ -1,0 +1,39 @@
+import pytest
+
+from bouncer import util
+
+
+def test_parse_document_raises_if_no_uri():
+    with pytest.raises(util.InvalidAnnotationError) as exc:
+        util.parse_document({
+            "_id": "annotation_id",
+            "_source": {}  # No "uri".
+        })
+    assert exc.value.reason == "annotation_has_no_uri"
+
+
+def test_parse_document_raises_if_uri_not_a_string():
+    with pytest.raises(util.InvalidAnnotationError) as exc:
+        util.parse_document({
+            "_id": "annotation_id",
+            "_source": {"uri": 52}  # "uri" isn't a string.
+        })
+    assert exc.value.reason == "uri_not_a_string"
+
+
+def test_parse_document_returns_annotation_id():
+    annotation_id = util.parse_document({
+        "_id": "annotation_id",
+        "_source": {"uri": "http://example.com/example.html"}
+    })[0]
+
+    assert annotation_id == "annotation_id"
+
+
+def test_parse_document_returns_document_uri():
+    document_uri = util.parse_document({
+        "_id": "annotation_id",
+        "_source": {"uri": "http://example.com/example.html"}
+    })[1]
+
+    assert document_uri == "http://example.com/example.html"

--- a/bouncer/test/views_test.py
+++ b/bouncer/test/views_test.py
@@ -57,6 +57,20 @@ class TestAnnotationController(object):
         assert data["extensionUrl"] == (
                 "http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
 
+    def test_annotation_when_uri_is_None(self, elasticsearch):
+        elasticsearch.Elasticsearch.return_value.get.return_value[
+            "_source"]["uri"] = None
+
+        with pytest.raises(httpexceptions.HTTPUnprocessableEntity):
+            views.AnnotationController(mock_request()).annotation()
+
+    def test_annotation_when_Elasticsearch_document_has_no_uri(self, elasticsearch):
+        elasticsearch.Elasticsearch.return_value.get.return_value[
+            "_source"] = {}
+
+        with pytest.raises(httpexceptions.HTTPUnprocessableEntity):
+            views.AnnotationController(mock_request()).annotation()
+
 
 def test_index_redirects_to_hypothesis():
     with pytest.raises(httpexceptions.HTTPFound) as exc:

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -1,0 +1,66 @@
+import elasticsearch
+from pyramid import i18n
+
+
+_ = i18n.TranslationStringFactory(__package__)
+
+
+def elasticsearch_client(settings):
+    return elasticsearch.Elasticsearch(
+        host=settings["elasticsearch_host"],
+        port=settings["elasticsearch_port"],
+    )
+
+
+class InvalidAnnotationError(Exception):
+
+    """Raised if an annotation from Elasticsearch can't be parsed."""
+
+    def __init__(self, message, reason):
+        """
+        Return a new InvalidAnnotationError instance.
+
+        :param message: a user-friendly error message
+        :type message: string
+
+        :param reason: a computer-friendly unique string identifying the reason
+            the exception was raised
+        :type reason: string
+
+        """
+        self.message = message
+        self.reason = reason
+
+    def __str__(self):
+        return self.message
+
+
+def parse_document(document):
+    """
+    Return the ID and URI from the given Elasticsearch annotation document.
+
+    Return the annotation ID and the annotated document's URI from the given
+    Elasticsearch annotation document.
+
+    :param document: the Elasticsearch annotation document to parse
+    :type document: dict
+
+    :rtype: 2-tuple of annotation ID (string) and document URI (string)
+
+    """
+    # We assume that Elasticsearch documents always have "_id" and "_source".
+    annotation_id = document["_id"]
+    annotation = document["_source"]
+
+    try:
+        document_uri = annotation["uri"]
+    except KeyError:
+        raise InvalidAnnotationError(
+            _("The annotation has no URI"), "annotation_has_no_uri")
+
+    if not isinstance(document_uri, str):
+        raise InvalidAnnotationError(
+            _("The annotation has an invalid document URI"),
+            "uri_not_a_string")
+
+    return (annotation_id, document_uri)

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -101,7 +101,7 @@ class AnnotationController(object):
             raise httpexceptions.HTTPUnprocessableEntity(
                 _("Sorry, but it looks like this annotation was made on a "
                   "document that is not publicly available. "
-                  "To view it’s annotations, a document's address must start "
+                  "To view its annotations, a document's address must start "
                   "with <code>http://</code> or <code>https://</code>."))
 
         via_url = "{via_base_url}/{uri}#annotations:{id}".format(

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -1,4 +1,5 @@
 import json
+from urllib import parse
 
 import elasticsearch
 from elasticsearch import exceptions
@@ -44,6 +45,10 @@ class AnnotationController(object):
             raise httpexceptions.HTTPUnprocessableEntity(
                 _("The annotation has an invalid document URI"))
 
+        # Remove any existing #fragment identifier from the URI before we
+        # append our own.
+        document_uri = parse.urldefrag(document_uri)[0]
+
         if not (document_uri.startswith("http://") or
                 document_uri.startswith("https://")):
             statsd.incr("views.annotation.422.not_an_http_or_https_document")
@@ -52,8 +57,6 @@ class AnnotationController(object):
                   "document that is not publicly available. "
                   "To view it’s annotations, a document's address must start "
                   "with <code>http://</code> or <code>https://</code>."))
-
-        # FIXME: Strip query params, anchors from document_uri here?
 
         via_url = "{via_base_url}/{uri}#annotations:{id}".format(
             via_base_url=settings["via_base_url"],


### PR DESCRIPTION
This is branched off of <https://github.com/hypothesis/bouncer/pull/10>. Added some defensive coding against Elasticsearch document variability. I've tested this on ~100,000 annotations from the production hypothes.is API.