### PR TITLE
Check chrome.runtime.lastError

### DIFF
--- a/bouncer/scripts/redirect.js
+++ b/bouncer/scripts/redirect.js
@@ -37,13 +37,18 @@ function redirect(navigateToFn) {
       {type: 'ping'},
       function (response) {
         var url;
-        if (response) {
+
+        if (response && !chrome.runtime.lastError) {
           // The user has our Chrome extension installed :)
           url = settings.extensionUrl;
         } else {
+          if (chrome.runtime.lastError) {
+            console.error(chrome.runtime.lastError);
+          }
           // The user doesn't have our Chrome extension installed :(
           url = settings.viaUrl;
         }
+
         navigateTo(url);
       }
     );

--- a/bouncer/scripts/test/redirect-test.js
+++ b/bouncer/scripts/test/redirect-test.js
@@ -13,6 +13,11 @@ describe('redirect()', function () {
         })
       };
     };
+    sinon.stub(window.console, 'error');
+  });
+
+  afterEach(function () {
+    window.console.error.restore();
   });
 
   it('redirects to Via if not Chrome', function () {
@@ -69,6 +74,40 @@ describe('redirect()', function () {
     assert.equal(
       navigateTo.calledWithExactly('https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q'),
       true);
+  });
+
+  it('redirects to Via if lastError is defined', function () {
+    window.chrome = {
+      runtime: {
+        sendMessage: function (id, message, callbackFunction) {
+          callbackFunction('Hey!');
+        },
+        lastError: {message: 'There was an error'}
+      }
+    };
+    var navigateTo = sinon.stub();
+
+    redirect(navigateTo);
+
+    assert.equal(navigateTo.calledOnce, true);
+    assert.equal(
+      navigateTo.calledWithExactly('https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q'),
+      true);
+  });
+
+  it('logs an error if lastError is defined', function () {
+    window.chrome = {
+      runtime: {
+        sendMessage: function (id, message, callbackFunction) {
+          callbackFunction('Hey!');
+        },
+        lastError: {message: 'There was an error'}
+      }
+    };
+
+    redirect(sinon.stub());
+
+    assert.equal(console.error.called, true);
   });
 
   it('redirects to Chrome extension if installed', function () {


### PR DESCRIPTION
If chrome.runtime.lastError is defined then log it with console.error()
and always redirect to Via instead of Chrome.

Fixes #9