### PR TITLE
Fix Python version in setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: BSD License",  # Should match "license"
                                                    # above.
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5'
     ],
 
     packages=find_packages(exclude=[]),


### PR DESCRIPTION
Just something I noticed while going through the code.