### PR TITLE
Makefile and Docker build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .coverage
 bouncer/static/scripts/bundle.js
 .cache
+dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+include Makefile AUTHORS CHANGES LICENSE NOTICE
+include *.rst
+include Dockerfile
+include gunicorn.conf.py
+include package.json
+graft bouncer/static
+graft bouncer/templates
+graft bouncer/scripts
+global-exclude __pycache__
+global-exclude *.py[co]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+BUILD_ID := $(shell python -c 'import bouncer.__about__; print(bouncer.__about__.__version__)')
+
 deps:
 	pip install --upgrade pip
 	pip install --upgrade wheel
@@ -7,9 +9,19 @@ deps:
 dev:
 	PYRAMID_RELOAD_TEMPLATES=1 gunicorn --reload "bouncer:app()"
 
-docker:
-	docker build -t hypothesis/bouncer:dev .
-
 test:
 	py.test --cov=bouncer bouncer
 	./node_modules/karma/bin/karma start karma.config.js
+
+.PHONY: dist
+dist: dist/bouncer-$(BUILD_ID).tar.gz
+
+dist/bouncer-$(BUILD_ID).tar.gz:
+	python setup.py sdist
+
+dist/bouncer-$(BUILD_ID): dist/bouncer-$(BUILD_ID).tar.gz
+	tar -C dist -zxf $<
+
+.PHONY: docker
+docker: dist/bouncer-$(BUILD_ID)
+	docker build -t hypothesis/bouncer:dev $<

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ dev:
 	PYRAMID_RELOAD_TEMPLATES=1 gunicorn --reload "bouncer:app()"
 
 docker:
-	docker build -t hypothesis/bouncer .
+	docker build -t hypothesis/bouncer:dev .
 
 test:
 	py.test --cov=bouncer bouncer

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,10 @@ dist/bouncer-$(BUILD_ID): dist/bouncer-$(BUILD_ID).tar.gz
 .PHONY: docker
 docker: dist/bouncer-$(BUILD_ID)
 	docker build -t hypothesis/bouncer:dev $<
+
+.PHONY: clean
+clean:
+	find . -type f -name "*.py[co]" -delete
+	find . -type d -name "__pycache__" -delete
+	rm -f node_modules/.uptodate bouncer.egg-info/.uptodate
+	rm -rf dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[check-manifest]
+ignore =
+    */test
+    */test/*
+    .*
+    node_modules
+
+[pep257]
+ignore = D202
+explain = true
+
+[yapf]
+based_on_style = pep8


### PR DESCRIPTION
* Adds make tasks for building standard Python sdist tarballs.
* Adds make clean task.
* Builds docker with the `dev` tag.
* Allows for future production Docker builds through the sdist tarballs.

I've been wondering recently how we actually build the development and production docker images with h. So after looking into it I've decided to implement it for bouncer.
There's probably some things missing or could be done better, please advise!