### PR TITLE
Serve static URLs with same protocol as the site

### DIFF
--- a/bouncer/__init__.py
+++ b/bouncer/__init__.py
@@ -37,7 +37,7 @@ def app():
     config.add_static_view(name="static", path="static")
     config.include("pyramid_jinja2")
     config.registry.settings["jinja2.filters"] = {
-        "static_url": "pyramid_jinja2.filters:static_url_filter"
+        "static_path": "pyramid_jinja2.filters:static_path_filter"
     }
     config.include("bouncer.views")
     config.include("bouncer.sentry")

--- a/bouncer/templates/annotation.html.jinja2
+++ b/bouncer/templates/annotation.html.jinja2
@@ -7,7 +7,7 @@
     <img alt="Redirecting"
           class="center spinner__icon"
           height="24"
-          src="{{'bouncer:static/images/hypothesis-icon.svg'|static_url}}"
+          src="{{'bouncer:static/images/hypothesis-icon.svg'|static_path}}"
           width="28">
     <div class="spinner__moving-ring"></div>
   </div>

--- a/bouncer/templates/base.html.jinja2
+++ b/bouncer/templates/base.html.jinja2
@@ -5,7 +5,7 @@
     <title>{{ title|safe }}</title>
     <link rel="stylesheet"
           type="text/css"
-          href="{{'bouncer:static/styles/bouncer.css'|static_url}}">
+          href="{{'bouncer:static/styles/bouncer.css'|static_path}}">
   </head>
   <body>
     <div class="center">

--- a/bouncer/templates/error.html.jinja2
+++ b/bouncer/templates/error.html.jinja2
@@ -3,7 +3,7 @@
 {% set title = message %}
 
 {% block content %}
-  <img src="{{'bouncer:static/images/sad-annotation.svg'|static_url}}">
+  <img src="{{'bouncer:static/images/sad-annotation.svg'|static_path}}">
   <p>
     {{ message|safe }}
   </p>


### PR DESCRIPTION
The CSS in the bouncer production deployment isn't being loaded because
of a mixed-content warning. Pyramid generates http:// URLs for static
assets, and bouncer is deployed with https://.

To make Pyramid generate static URLs with the same protocol as the
request you need to do:

    config.add_static_view(name="//htp.is/static", path="static")

But we can't hardcode "//htp.is/static" (this differs between our stage
and production deployments, for one thing) so make it configurable by a
new environment variable.