### PR TITLE
Fix the front page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,12 @@ CHROME_EXTENSION_ID
   The ID of the Hypothesis Chrome extension that bouncer will communicate with
   (default: the ID of the `official Hypothesis Chrome extension <https://chrome.google.com/webstore/detail/hypothesis-web-pdf-annota/bjfhmglciegochdpefhhlphglcehbmek>`_)
 
+DEBUG
+  If ``DEBUG`` is set (to any value) then tracebacks will be printed to the
+  terminal for any unexpected Python exceptions. If there is no ``DEBUG``
+  variable set in the environment then unexpected Python exceptions will be
+  reported to Sentry and a generic error page shown to the user.
+
 ELASTICSEARCH_HOST
   The hostname of the Elasticsearch server that bouncer will read annotations
   from (default: localhost)

--- a/bouncer/__init__.py
+++ b/bouncer/__init__.py
@@ -15,10 +15,16 @@ def settings():
     if via_base_url.endswith("/"):
         via_base_url = via_base_url[:-1]
 
+    if "DEBUG" in os.environ:
+        debug = True
+    else:
+        debug = False
+
     return {
         "chrome_extension_id": os.environ.get(
             "CHROME_EXTENSION_ID",
             "bjfhmglciegochdpefhhlphglcehbmek"),
+        "debug": debug,
         "elasticsearch_host": os.environ.get("ELASTICSEARCH_HOST",
                                              "localhost"),
         "elasticsearch_index": os.environ.get("ELASTICSEARCH_INDEX",

--- a/bouncer/sentry.py
+++ b/bouncer/sentry.py
@@ -5,19 +5,6 @@ import raven
 from bouncer import __about__
 
 
-def raven_tween_factory(handler, _):
-    """Return a tween that reports uncaught exceptions to Sentry."""
-    def raven_tween(request):
-        """Report uncaught exceptions to Sentry."""
-        try:
-            return handler(request)
-        except:
-            request.raven.captureException()
-            raise
-
-    return raven_tween
-
-
 def get_raven_client(request):
     """Return the Raven client for reporting crashes to Sentry."""
     client = request.registry["raven.client"]
@@ -41,7 +28,3 @@ def includeme(config):
         get_raven_client,
         name="raven",
         reify=True)
-
-    config.add_tween(
-        "bouncer.sentry.raven_tween_factory",
-        under=tweens.EXCVIEW)


### PR DESCRIPTION
```
Fix exception handling

1. Fix the front page.

   The front page raises an HTTPFound which is supposed to redirect the
   browser, but which was being caught by the custom exception view
   (which was catching all HTTPExceptions) and turned into an error page.

   We no longer have a conteext=httpexceptions.HTTPException view so the
   redirect now works as intended.

2. Don't report HTTPRedirection (3xx) and HTTPNotFound (404) to Sentry.

   These were being caught by the Raven tween and reported to Sentry.

   The Raven tween is now gone, replaced by an exception view (see 3
   below) and we have an
   @view.view_config(context=httpexceptions.HTTPError)
   @view.view_config(context=httpexceptions.HTTPServerError)
   view that catches deliberately raised Pyramid exceptions and shows
   the user an error page but does not report them to Sentry.

3. Show a nice error page for non-httpexceptions, and report them to
   Sentry.

   If a bug in the code raises an arbitrary uncaught exception
   (DivisionByZero, AssertionError, ...) this is now caught by the new
   @view.view_config(context=Exception) and reported to Sentry,
   and then a generic error page is shown to the user.

   Even though HTTPException is an Exception subclass,
   context=Exception doesn't catch it

   We don't want to reveal bugs in the production code by showing
   details of these exceptions to users, but we do want to report the
   details to Sentry for ourselves.

4. If the environment variable DEBUG is set then print tracebacks to the
   terminal instead of reporting to Sentry and showing a generic error
   page.
```