### PR TITLE
Display document url when redirecting from bouncer.

### DIFF
--- a/bouncer/templates/annotation.html.jinja2
+++ b/bouncer/templates/annotation.html.jinja2
@@ -1,17 +1,17 @@
 {% extends "templates/base.html.jinja2" %}
 
-{% set title = _("Hypothesis: Redirecting you&hellip;") %}
+{% set title = _("Hypothesis: Annotation for %(site)s" )|format(site=pretty_url)  %}
 
 {% block content %}
   <div class="center spinner__stationary-ring">
-    <img alt="Redirecting"
+    <img alt="{% trans %}Loading annotation for {{ pretty_url }}{% endtrans %}"
           class="center spinner__icon"
           height="24"
           src="{{'bouncer:static/images/hypothesis-icon.svg'|static_path}}"
           width="28">
     <div class="spinner__moving-ring"></div>
   </div>
-  <p class="spinner__text">{% trans %}Redirecting{% endtrans %}</p>
+  <p class="spinner__text">{% trans %}Loading annotation for {{ pretty_url }}{% endtrans %}</p>
 {% endblock %}
 
 {% block scripts %}

--- a/bouncer/test/views_test.py
+++ b/bouncer/test/views_test.py
@@ -147,6 +147,19 @@ class TestAnnotationController(object):
         assert data["viaUrl"] == (
                 "https://via.hypothes.is/http://example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
 
+    def test_annotation_returns_pretty_url(self):
+        template_data = views.AnnotationController(mock_request()).annotation()
+
+        assert template_data["pretty_url"] == "www.example.com"
+
+    def test_annotation_truncates_pretty_url(self, parse_document):
+        parse_document.return_value[1] = (
+            "http://www.abcdefghijklmnopqrst.com/example.html")
+
+        template_data = views.AnnotationController(mock_request()).annotation()
+
+        assert template_data["pretty_url"] == "www.abcdefghijklmnop&hellip;"
+
 
 @pytest.mark.usefixtures("statsd")
 def test_index_increments_stat(statsd):

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -13,6 +13,12 @@ from bouncer import util
 _ = i18n.TranslationStringFactory(__package__)
 
 
+#: The maximum length that the "netloc" (the www.example.com part in
+#: http://www.example.com/example) can be in the pretty URL that is displayed
+#: to the user before it gets truncated.
+NETLOC_MAX_LENGTH = 20
+
+
 @view.view_defaults(renderer="bouncer:templates/annotation.html.jinja2")
 class AnnotationController(object):
 
@@ -60,10 +66,9 @@ class AnnotationController(object):
         extension_url = "{uri}#annotations:{id}".format(
             uri=document_uri, id=annotation_id)
 
-        netloc_max_length = 20
         parsed_url = parse.urlparse(document_uri)
-        pretty_url = parsed_url.netloc[:netloc_max_length]
-        if len(parsed_url.netloc) > netloc_max_length:
+        pretty_url = parsed_url.netloc[:NETLOC_MAX_LENGTH]
+        if len(parsed_url.netloc) > NETLOC_MAX_LENGTH:
           pretty_url = pretty_url+ jinja2.Markup("&hellip;")
 
         statsd.incr("views.annotation.200.annotation_found")

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -69,7 +69,7 @@ class AnnotationController(object):
         parsed_url = parse.urlparse(document_uri)
         pretty_url = parsed_url.netloc[:NETLOC_MAX_LENGTH]
         if len(parsed_url.netloc) > NETLOC_MAX_LENGTH:
-          pretty_url = pretty_url+ jinja2.Markup("&hellip;")
+          pretty_url = pretty_url + jinja2.Markup("&hellip;")
 
         statsd.incr("views.annotation.200.annotation_found")
         return {

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -60,6 +60,11 @@ class AnnotationController(object):
         extension_url = "{uri}#annotations:{id}".format(
             uri=document_uri, id=annotation_id)
 
+        parsed_url = parse.urlparse(document_uri)
+        pretty_url = parsed_url.netloc[0:20]
+        if len(parsed_url.netloc) > 20:
+          pretty_url = pretty_url+ "..."
+
         statsd.incr("views.annotation.200.annotation_found")
         return {
             "data": json.dumps({
@@ -68,7 +73,8 @@ class AnnotationController(object):
                 "chromeExtensionId": settings["chrome_extension_id"],
                 "viaUrl": via_url,
                 "extensionUrl": extension_url,
-            })
+            }),
+            "pretty_url": pretty_url
         }
 
 

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -1,6 +1,7 @@
 import json
 from urllib import parse
 
+import jinja2
 from elasticsearch import exceptions
 from pyramid import httpexceptions
 from pyramid import i18n

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -60,10 +60,11 @@ class AnnotationController(object):
         extension_url = "{uri}#annotations:{id}".format(
             uri=document_uri, id=annotation_id)
 
+        netloc_max_length = 20
         parsed_url = parse.urlparse(document_uri)
-        pretty_url = parsed_url.netloc[0:20]
-        if len(parsed_url.netloc) > 20:
-          pretty_url = pretty_url+ "..."
+        pretty_url = parsed_url.netloc[:netloc_max_length]
+        if len(parsed_url.netloc) > netloc_max_length:
+          pretty_url = pretty_url+ jinja2.Markup("&hellip;")
 
         statsd.incr("views.annotation.200.annotation_found")
         return {


### PR DESCRIPTION
Currently the text under the spinner and the page title say
"redirecting." Change that to "Loading annotation for <url/path>"
so that the user has a better idea of what is hapening and what
page he can expect to be redirected to.