### PR TITLE
Switch default index to `hypothesis`

### DIFF
--- a/bouncer/__init__.py
+++ b/bouncer/__init__.py
@@ -28,7 +28,7 @@ def settings():
         "elasticsearch_host": os.environ.get("ELASTICSEARCH_HOST",
                                              "localhost"),
         "elasticsearch_index": os.environ.get("ELASTICSEARCH_INDEX",
-                                              "annotator"),
+                                              "hypothesis"),
         "elasticsearch_port": os.environ.get("ELASTICSEARCH_PORT",
                                              "9200"),
         "hypothesis_url": os.environ.get("HYPOTHESIS_URL",


### PR DESCRIPTION
This should be merged after we're happy with the PostgreSQL migration and want
to switch bouncer to the new index.