### PR TITLE
Redirect PDF annotations

### DIFF
--- a/bouncer/test/util_test.py
+++ b/bouncer/test/util_test.py
@@ -37,3 +37,30 @@ def test_parse_document_returns_document_uri():
     })[1]
 
     assert document_uri == "http://example.com/example.html"
+
+def test_parse_document_returns_document_uri_from_links_when_pdf():
+    document_uri = util.parse_document({
+        "_id": "annotation_id",
+        "_source": {
+            "target": [{"source": "urn:x-pdf:the-fingerprint"}],
+            "document": {
+                "link": [{"href": "http://example.com/foo.pdf"}]
+            }
+        }
+    })[1]
+
+    assert document_uri == "http://example.com/foo.pdf"
+
+
+def test_parse_document_raises_when_uri_from_links_not_string_for_pdfs():
+    with pytest.raises(util.InvalidAnnotationError) as exc:
+        util.parse_document({
+            "_id": "annotation_id",
+            "_source": {
+                "target": [{"source": "urn:x-pdf:the-fingerprint"}],
+                "document": {
+                    "link": [{"href": 52}]
+                }
+            }
+        })
+    assert exc.value.reason == "uri_not_a_string"

--- a/bouncer/test/util_test.py
+++ b/bouncer/test/util_test.py
@@ -16,7 +16,7 @@ def test_parse_document_raises_if_uri_not_a_string():
     with pytest.raises(util.InvalidAnnotationError) as exc:
         util.parse_document({
             "_id": "annotation_id",
-            "_source": {"uri": 52}  # "uri" isn't a string.
+            "_source": {"target": [{"source": 52}]}  # "uri" isn't a string.
         })
     assert exc.value.reason == "uri_not_a_string"
 
@@ -24,7 +24,7 @@ def test_parse_document_raises_if_uri_not_a_string():
 def test_parse_document_returns_annotation_id():
     annotation_id = util.parse_document({
         "_id": "annotation_id",
-        "_source": {"uri": "http://example.com/example.html"}
+        "_source": {"target": [{"source": "http://example.com/example.html"}]}
     })[0]
 
     assert annotation_id == "annotation_id"
@@ -33,7 +33,7 @@ def test_parse_document_returns_annotation_id():
 def test_parse_document_returns_document_uri():
     document_uri = util.parse_document({
         "_id": "annotation_id",
-        "_source": {"uri": "http://example.com/example.html"}
+        "_source": {"target": [{"source": "http://example.com/example.html"}]}
     })[1]
 
     assert document_uri == "http://example.com/example.html"

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -53,7 +53,9 @@ def parse_document(document):
     annotation = document["_source"]
 
     try:
-        document_uri = annotation["uri"]
+        targets = annotation["target"]
+        if targets:
+            document_uri = targets[0]["source"]
     except KeyError:
         raise InvalidAnnotationError(
             _("The annotation has no URI"), "annotation_has_no_uri")


### PR DESCRIPTION
Fall back to http document link when PDF annotation
    
We now store the PDF fingerprint in the target source for annotations
made on PDF files. To be able to still redirect the user to the PDF, we
try and load an http/https URL from the document's links.
