### PR TITLE
Don't break the back button

### DIFF
--- a/bouncer/scripts/redirect.js
+++ b/bouncer/scripts/redirect.js
@@ -8,7 +8,7 @@ function getSettings(document) {
 
 /** Navigate the browser to the given URL. */
 function navigateTo(url) {
-  window.location = url;
+  window.location.replace(url);
 }
 
 /** Navigate the browser to the requested annotation.


### PR DESCRIPTION
Use window.location.replace(), instead of assigning to window.location,
to redirect the browser from JavaScript.

The difference is that the page that did the window.location.replace()
(the bouncer https://hyp.is/* page) will not be added to the browser's
history.

Previously bouncer was breaking the browser's back button:

1. User is on page A and clicks on a bouncer (hyp.is) link
2. The JavaScript on the bouncer (hyp.is) page redirects them to
   example.com
3. On example.com the user clicks the browser's back button and is taken
   back to the bouncer (hyp.is) page.
4. The JavaScript on the bouncer (hyp.is) page redirects them to
   example.com...

The user cannot get back to page A (except by hitting back twice
quickly, or long-clicking on back and selecting it from the dropdown).

With window.location.replace() we get the correct behaviour for an
interstitial page:

1. User is on page A and clicks on a bouncer (hyp.is) link
2. The JavaScript on the bouncer (hyp.is) page redirects them to
   example.com
3. On example.com the user clicks the browser's back button and is taken
   back to page A