### PR TITLE
Read web link from new `web_uri` when a URN is found

### DIFF
--- a/bouncer/test/util_test.py
+++ b/bouncer/test/util_test.py
@@ -38,29 +38,26 @@ def test_parse_document_returns_document_uri():
 
     assert document_uri == "http://example.com/example.html"
 
-def test_parse_document_returns_document_uri_from_links_when_pdf():
+
+def test_parse_document_returns_document_uri_from_web_uri_when_pdf():
     document_uri = util.parse_document({
         "_id": "annotation_id",
         "_source": {
             "target": [{"source": "urn:x-pdf:the-fingerprint"}],
-            "document": {
-                "link": [{"href": "http://example.com/foo.pdf"}]
-            }
+            "document": {"web_uri": "http://example.com/foo.pdf"}
         }
     })[1]
 
     assert document_uri == "http://example.com/foo.pdf"
 
 
-def test_parse_document_raises_when_uri_from_links_not_string_for_pdfs():
+def test_parse_document_raises_when_uri_from_web_uri_not_string_for_pdfs():
     with pytest.raises(util.InvalidAnnotationError) as exc:
         util.parse_document({
             "_id": "annotation_id",
             "_source": {
                 "target": [{"source": "urn:x-pdf:the-fingerprint"}],
-                "document": {
-                    "link": [{"href": 52}]
-                }
+                "document": {"web_uri": 52}
             }
         })
     assert exc.value.reason == "uri_not_a_string"

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -63,14 +63,9 @@ def parse_document(document):
 
     if isinstance(document_uri, str) and document_uri.startswith("urn:x-pdf:"):
         try:
-            links = annotation["document"]["link"]
-            for link in links:
-                href = link["href"]
-                if not isinstance(href, str):
-                    document_uri = href
-                elif href.startswith(("http://", "https://")):
-                    document_uri = href
-                    break
+            web_uri = annotation["document"]["web_uri"]
+            if web_uri:
+                document_uri = web_uri
         except KeyError:
             pass
 


### PR DESCRIPTION
This relies on https://github.com/hypothesis/h/pull/3869 being merged,
deployed to production, and a full reindex being run. This will also fix
the issue that is tracked here: https://github.com/hypothesis/h/issues/3867