### PR TITLE
Extract Elasticsearch client into own module

### DIFF
--- a/bouncer/__init__.py
+++ b/bouncer/__init__.py
@@ -20,21 +20,24 @@ def settings():
     else:
         debug = False
 
-    return {
+    result = {
         "chrome_extension_id": os.environ.get(
             "CHROME_EXTENSION_ID",
             "bjfhmglciegochdpefhhlphglcehbmek"),
         "debug": debug,
-        "elasticsearch_host": os.environ.get("ELASTICSEARCH_HOST",
-                                             "localhost"),
         "elasticsearch_index": os.environ.get("ELASTICSEARCH_INDEX",
                                               "hypothesis"),
-        "elasticsearch_port": os.environ.get("ELASTICSEARCH_PORT",
-                                             "9200"),
         "hypothesis_url": os.environ.get("HYPOTHESIS_URL",
                                          "https://hypothes.is"),
         "via_base_url": via_base_url,
     }
+
+    if 'ELASTICSEARCH_HOST' in os.environ:
+        result['elasticsearch_host'] = os.environ['ELASTICSEARCH_HOST']
+    if 'ELASTICSEARCH_PORT' in os.environ:
+        result['elasticsearch_port'] = int(os.environ['ELASTICSEARCH_PORT'])
+
+    return result
 
 
 def app():
@@ -46,6 +49,7 @@ def app():
         "static_path": "pyramid_jinja2.filters:static_path_filter",
         "static_url": "pyramid_jinja2.filters:static_url_filter"
     }
+    config.include("bouncer.search")
     config.include("bouncer.views")
     config.include("bouncer.sentry")
     return config.make_wsgi_app()

--- a/bouncer/search.py
+++ b/bouncer/search.py
@@ -1,0 +1,20 @@
+from elasticsearch import Elasticsearch
+
+
+def get_client(settings):
+    """Return a client for the Elasticsearch index."""
+    host = {'host': settings['elasticsearch_host'],
+            'port': settings['elasticsearch_port']}
+
+    return Elasticsearch([host])
+
+
+def includeme(config):
+    settings = config.registry.settings
+    settings.setdefault('elasticsearch_host', 'localhost')
+    settings.setdefault('elasticsearch_port', 9200)
+
+    config.registry['es.client'] = get_client(settings)
+    config.add_request_method(lambda r: r.registry['es.client'],
+                              name='es',
+                              reify=True)

--- a/bouncer/test/search_test.py
+++ b/bouncer/test/search_test.py
@@ -1,0 +1,36 @@
+from mock import (
+    ANY,
+    MagicMock,
+    patch,
+)
+
+from elasticsearch import Elasticsearch
+
+from bouncer.search import get_client, includeme
+
+
+class TestGetClient(object):
+    def test_returns_client(self):
+        client = get_client({'elasticsearch_host': 'foo',
+                             'elasticsearch_port': 9200})
+
+        assert isinstance(client, Elasticsearch)
+
+    @patch('bouncer.search.Elasticsearch')
+    def test_configures_client(self, es_mock):
+        get_client({'elasticsearch_host': 'foo',
+                    'elasticsearch_port': 9200})
+
+
+        es_mock.assert_called_once_with([{'host': 'foo', 'port': 9200}])
+
+
+def test_includeme():
+    configurator = MagicMock()
+
+    includeme(configurator)
+
+    configurator.add_request_method.assert_called_once_with(ANY,
+                                                            name='es',
+                                                            reify=True)
+

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -1,15 +1,7 @@
-import elasticsearch
 from pyramid import i18n
 
 
 _ = i18n.TranslationStringFactory(__package__)
-
-
-def elasticsearch_client(settings):
-    return elasticsearch.Elasticsearch(
-        host=settings["elasticsearch_host"],
-        port=settings["elasticsearch_port"],
-    )
 
 
 class InvalidAnnotationError(Exception):

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -32,7 +32,7 @@ class AnnotationController(object):
         settings = self.request.registry.settings
 
         try:
-            document = util.elasticsearch_client(settings).get(
+            document = self.request.es.get(
                 index=settings["elasticsearch_index"],
                 doc_type="annotation",
                 id=self.request.matchdict["id"])


### PR DESCRIPTION
This commit extracts the Elasticsearch client (and its provision on the request object) into its own module in preparation for additional changes to the client to include: TLS support, and possibly AWS Auth (signed requests) so that we don't need to whitelist IPs on our Elasticsearch cluster.