### PR TITLE
Optional AWS Auth v4 request signing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,12 @@ ELASTICSEARCH_PORT
   The port of the Elasticsearch server that bouncer will read annotations
   from (default: 9200)
 
+ELASTICSEARCH_AWS_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,REGION}
+  If all three of these environment variables are set, bouncer will assume that
+  it must connect to Elasticsearch over HTTPS and will enable AWS Auth v4
+  request signing with the given credentials. This allows making requests to an
+  AWS Elasticsearch domain as an IAM user.
+
 HYPOTHESIS_URL
   The URL of the Hypothesis front page that requests to bouncer's front page
   will be redirected to (default: https://hypothes.is)

--- a/bouncer/__init__.py
+++ b/bouncer/__init__.py
@@ -36,6 +36,12 @@ def settings():
         result['elasticsearch_host'] = os.environ['ELASTICSEARCH_HOST']
     if 'ELASTICSEARCH_PORT' in os.environ:
         result['elasticsearch_port'] = int(os.environ['ELASTICSEARCH_PORT'])
+    if 'ELASTICSEARCH_AWS_ACCESS_KEY_ID' in os.environ:
+        result['elasticsearch_aws_access_key_id'] = os.environ['ELASTICSEARCH_AWS_ACCESS_KEY_ID']
+    if 'ELASTICSEARCH_AWS_SECRET_ACCESS_KEY' in os.environ:
+        result['elasticsearch_aws_secret_access_key'] = os.environ['ELASTICSEARCH_AWS_SECRET_ACCESS_KEY']
+    if 'ELASTICSEARCH_AWS_REGION' in os.environ:
+        result['elasticsearch_aws_region'] = os.environ['ELASTICSEARCH_AWS_REGION']
 
     return result
 

--- a/bouncer/search.py
+++ b/bouncer/search.py
@@ -1,12 +1,30 @@
-from elasticsearch import Elasticsearch
+import certifi
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
 
 
 def get_client(settings):
     """Return a client for the Elasticsearch index."""
     host = {'host': settings['elasticsearch_host'],
             'port': settings['elasticsearch_port']}
+    kwargs = {}
 
-    return Elasticsearch([host])
+    have_aws_creds = ('elasticsearch_aws_access_key_id' in settings and
+                      'elasticsearch_aws_secret_access_key' in settings and
+                      'elasticsearch_aws_region' in settings)
+    if have_aws_creds:
+        auth = AWS4Auth(settings['elasticsearch_aws_access_key_id'],
+                        settings['elasticsearch_aws_secret_access_key'],
+                        settings['elasticsearch_aws_region'],
+                        'es')
+
+        kwargs['http_auth'] = auth
+        kwargs['use_ssl'] = True
+        kwargs['verify_certs'] = True
+        kwargs['ca_certs'] = certifi.where()
+        kwargs['connection_class'] = RequestsHttpConnection
+
+    return Elasticsearch([host], **kwargs)
 
 
 def includeme(config):

--- a/bouncer/test/search_test.py
+++ b/bouncer/test/search_test.py
@@ -4,7 +4,8 @@ from mock import (
     patch,
 )
 
-from elasticsearch import Elasticsearch
+import certifi
+from elasticsearch import Elasticsearch, RequestsHttpConnection
 
 from bouncer.search import get_client, includeme
 
@@ -21,8 +22,35 @@ class TestGetClient(object):
         get_client({'elasticsearch_host': 'foo',
                     'elasticsearch_port': 9200})
 
-
         es_mock.assert_called_once_with([{'host': 'foo', 'port': 9200}])
+
+    @patch('bouncer.search.AWS4Auth')
+    @patch('bouncer.search.Elasticsearch')
+    def test_configures_aws_auth(self, es_mock, awsauth_mock):
+        get_client({'elasticsearch_host': 'foo',
+                    'elasticsearch_port': 9200,
+                    'elasticsearch_aws_access_key_id': 'foo',
+                    'elasticsearch_aws_secret_access_key': 'bar',
+                    'elasticsearch_aws_region': 'spain'})
+
+        awsauth_mock.assert_called_once_with('foo', 'bar', 'spain', 'es')
+
+    @patch('bouncer.search.AWS4Auth')
+    @patch('bouncer.search.Elasticsearch')
+    def test_configures_es_for_aws_auth(self, es_mock, awsauth_mock):
+        auth_result = awsauth_mock.return_value
+        get_client({'elasticsearch_host': 'foo',
+                    'elasticsearch_port': 9200,
+                    'elasticsearch_aws_access_key_id': 'foo',
+                    'elasticsearch_aws_secret_access_key': 'bar',
+                    'elasticsearch_aws_region': 'spain'})
+
+        es_mock.assert_called_once_with([{'host': 'foo', 'port': 9200}],
+                                        http_auth=auth_result,
+                                        use_ssl=True,
+                                        verify_certs=True,
+                                        ca_certs=certifi.where(),
+                                        connection_class=RequestsHttpConnection)
 
 
 def test_includeme():

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,13 @@ setup(
     packages=find_packages(exclude=[]),
 
     install_requires=[
+        "certifi==2016.9.26",
         "elasticsearch>=2.0.0,<3.0.0",
         "gunicorn==19.4.5",
         "pyramid==1.6.1",
         "pyramid-jinja2==2.6.2",
+        "requests==2.12.4",
+        "requests-aws4auth==0.9",
         "raven==5.10.2",
         "statsd==3.2.1",
     ],


### PR DESCRIPTION
This commit enables AWS Auth v4 request signing if all three of the following environment variables are set:

- ELASTICSEARCH_AWS_ACCESS_KEY_ID
- ELASTICSEARCH_AWS_SECRET_ACCESS_KEY
- ELASTICSEARCH_AWS_REGION

This allows us to make requests to an AWS Elasticsearch cluster without knowing in advance the public IP from which those requests will be made.

When these environment variables are not set, the configuration is exactly as before.

~_**N.B.** This PR depends on #33 and will need rebasing after that merges._~