### PR TITLE
use quote and text (if available) to enhance share card

### DIFF
--- a/bouncer/__init__.py
+++ b/bouncer/__init__.py
@@ -2,3 +2,4 @@ from bouncer._version import get_version
 
 __all__ = ('__version__',)
 __version__ = get_version()
+

--- a/bouncer/templates/annotation.html.jinja2
+++ b/bouncer/templates/annotation.html.jinja2
@@ -3,6 +3,9 @@
 {% set title = _("Hypothesis: Annotation for %(site)s" )|format(site=pretty_url)  %}
 {% set meta_title = _("Annotation for %(site)s" )|format(site=pretty_url)  %}
 
+{% set quote = quote  %}
+{% set text = text  %}
+
 {% block content %}
   <div class="center spinner__stationary-ring">
     <img alt="{% trans %}Loading annotation for {{ pretty_url }}{% endtrans %}"

--- a/bouncer/templates/annotation.html.jinja2
+++ b/bouncer/templates/annotation.html.jinja2
@@ -1,8 +1,5 @@
 {% extends "templates/base.html.jinja2" %}
 
-{% set title = _("Hypothesis: Annotation for %(site)s" )|format(site=pretty_url)  %}
-{% set meta_title = _("Annotation for %(site)s" )|format(site=pretty_url)  %}
-
 {% block content %}
   <div class="center spinner__stationary-ring">
     <img alt="{% trans %}Loading annotation for {{ pretty_url }}{% endtrans %}"

--- a/bouncer/templates/annotation.html.jinja2
+++ b/bouncer/templates/annotation.html.jinja2
@@ -3,9 +3,6 @@
 {% set title = _("Hypothesis: Annotation for %(site)s" )|format(site=pretty_url)  %}
 {% set meta_title = _("Annotation for %(site)s" )|format(site=pretty_url)  %}
 
-{% set quote = quote  %}
-{% set text = text  %}
-
 {% block content %}
   <div class="center spinner__stationary-ring">
     <img alt="{% trans %}Loading annotation for {{ pretty_url }}{% endtrans %}"

--- a/bouncer/templates/base.html.jinja2
+++ b/bouncer/templates/base.html.jinja2
@@ -3,7 +3,7 @@
   <head>
     <meta charset=utf-8>
 
-    {% if visibility != 'private' %}
+    {% if shared and group == '__world__'  %}
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@hypothes_is" />

--- a/bouncer/templates/base.html.jinja2
+++ b/bouncer/templates/base.html.jinja2
@@ -5,14 +5,14 @@
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@hypothes_is" />
-    <meta name="twitter:title" content="{{ meta_title|safe }}" />
-    <meta name="twitter:description" content="Follow the link to see this annotation on the original page.  Use Hypothesis to annotate the Web and PDFs." />
+    <meta name="twitter:title" content="{{ quote }}" />
+    <meta name="twitter:description" content="{{ text }}" />
     <meta name="twitter:image" content="{{ 'bouncer:static/images/twitter.png'|static_url }}" />
 
     <meta property="og:type" content="article"/>
     <meta property="og:site_name" content="Hypothes.is"/>
-    <meta property="og:title" content="Check out this annotation."/>
-    <meta property="og:description" content="Follow the link to see this annotation on the original page. Use Hypothesis to annotate the Web and PDFs."/>
+    <meta property="og:title" content="{{ quote }}"/>
+    <meta property="og:description" content="{{ text }}"/>
     <meta property="og:image" content="{{'bouncer:static/images/facebook.png'|static_url }}"/>
 
     <title>{{ title|safe }}</title>

--- a/bouncer/templates/base.html.jinja2
+++ b/bouncer/templates/base.html.jinja2
@@ -31,8 +31,4 @@
   </body>
   {% block scripts %}{% endblock %}
 
-<div> can_reveal_metadata {{ can_reveal_metadata }}</div>
-<div>quote {{ quote }}</div>
-<div>text {{ text }}</div>
-<div>title {{ title }}</div>
 </html>

--- a/bouncer/templates/base.html.jinja2
+++ b/bouncer/templates/base.html.jinja2
@@ -3,6 +3,8 @@
   <head>
     <meta charset=utf-8>
 
+    {% if visibility != 'private' %}
+
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@hypothes_is" />
     <meta name="twitter:title" content="{{ quote }}" />
@@ -14,6 +16,8 @@
     <meta property="og:title" content="{{ quote }}"/>
     <meta property="og:description" content="{{ text }}"/>
     <meta property="og:image" content="{{'bouncer:static/images/facebook.png'|static_url }}"/>
+
+    {% endif %}
 
     <title>{{ title|safe }}</title>
     <link rel="stylesheet"

--- a/bouncer/templates/base.html.jinja2
+++ b/bouncer/templates/base.html.jinja2
@@ -3,7 +3,7 @@
   <head>
     <meta charset=utf-8>
 
-    {% if shared and group == '__world__'  %}
+    {% if can_reveal_metadata == True %}
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@hypothes_is" />
@@ -30,4 +30,9 @@
     </div>
   </body>
   {% block scripts %}{% endblock %}
+
+<div> can_reveal_metadata {{ can_reveal_metadata }}</div>
+<div>quote {{ quote }}</div>
+<div>text {{ text }}</div>
+<div>title {{ title }}</div>
 </html>

--- a/bouncer/templates/base.html.jinja2
+++ b/bouncer/templates/base.html.jinja2
@@ -3,7 +3,7 @@
   <head>
     <meta charset=utf-8>
 
-    {% if can_reveal_metadata == True %}
+    {% if show_metadata == True %}
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@hypothes_is" />

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -128,12 +128,12 @@ def get_pretty_url(url):
     """
     try:
         parsed_url = parse.urlparse(url)
-        pretty_url = parsed_url.netloc[:NETLOC_MAX_LENGTH]
-        if len(parsed_url.netloc) > NETLOC_MAX_LENGTH:
-            pretty_url = pretty_url + jinja2.Markup("&hellip;")
-    except (ValueError, AttributeError) as e:
+    except (AttributeError, ValueError) as e:
         return None
 
+    pretty_url = parsed_url.netloc[:NETLOC_MAX_LENGTH]
+    if len(parsed_url.netloc) > NETLOC_MAX_LENGTH:
+        pretty_url += jinja2.Markup("&hellip;")
     return pretty_url
 
 

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -47,11 +47,12 @@ def parse_document(document):
 
     annotation_id = document["_id"]
     annotation = document["_source"]
+    quote = ""
+    text = ""
 
     document_uri = None
 
-    quote = None
-    if annotation["text"] == "":
+    if "text" not in annotation:
         text = "Follow this link to see the annotation on the original page."
     else:
         text = annotation["text"]
@@ -75,8 +76,8 @@ def parse_document(document):
         except KeyError:
             pass
 
-    if quote is None:
-        quote = "Annotation for " + document_uri
+    if quote == "":
+        quote = "Annotation for {}".format(document_uri)
 
     if document_uri is None:
         raise InvalidAnnotationError(

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -49,7 +49,9 @@ def parse_document(document):
     group = annotation["group"]
     shared = annotation["shared"]
 
-    text = annotation.get('text', 'Follow this link to see the annotation on the original page.')
+    boilerplate_text = (
+        'Follow this link to see the annotation on the original page.')
+    text = (annotation.get('text', boilerplate_text))
 
     document_uri = None
     quote = None
@@ -60,10 +62,10 @@ def parse_document(document):
             document_uri = targets[0]["source"]
             if 'selector' in targets[0]:
                 selectors = targets[0]["selector"]
-                for selector in selectors:
-                    if "type" in selector and selector["type"] == "TextQuoteSelector":
-                        if "exact" in selector:
-                            quote = selector["exact"]
+                for sel in selectors:
+                    if "type" in sel and sel["type"] == ("TextQuoteSelector"):
+                        if "exact" in sel:
+                            quote = sel["exact"]
     except KeyError:
         pass
 
@@ -84,7 +86,8 @@ def parse_document(document):
 
     if quote is None:
         raise InvalidAnnotationError(
-            _("The annotation has a TextQuoteSelector but no exact quote"), "annotation_has_no_quote")  
+            _("The annotation has a TextQuoteSelector but no exact quote"),
+            "annotation_has_no_quote")
 
     if not isinstance(document_uri, str):
         raise InvalidAnnotationError(

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -11,6 +11,17 @@ _ = i18n.TranslationStringFactory(__package__)
 #: to the user before it gets truncated.
 NETLOC_MAX_LENGTH = 30
 
+# The metadata we are populating has fields that play the roles of Title and
+# Description on Twitter and Facebook share cards. We map the annotation's `quote`
+# field to Title. If we lack a quote we try to form one from `document_uri`
+# If that fails, we fall back to this minimal version.
+ANNOTATION_BOILERPLATE_QUOTE = _("Hypothesis annotation")
+
+# We map the annotation's `text` field to Description. If it's empty, we fall back
+# to this minimal version.
+ANNOTATION_BOILERPLATE_TEXT = (
+    _('Follow this link to see the annotation in context'))
+
 
 class InvalidAnnotationError(Exception):
 
@@ -57,32 +68,33 @@ def parse_document(document):
     group = annotation["group"]
     is_shared = annotation["shared"] is True
 
-    can_reveal_metadata = is_shared and group == "__world__"
+    show_metadata = is_shared and group == "__world__"
 
     document_uri = None
+
+    # This will fill the Title slot in Twitter/OG metadata
     quote = None
-    text = annotation.get('text', make_boilerplate_text())
-    if text == "":
-        text = make_boilerplate_text()
+
+    # This will fill the Description slot in Twitter/OG metadata
+    text = annotation.get('text')
+    if not text:
+        text = ANNOTATION_BOILERPLATE_TEXT
 
     try:
         targets = annotation["target"]
         if targets:
             document_uri = targets[0]["source"]
-            if 'selector' in targets[0]:
-                selectors = targets[0]["selector"]
-                for selector in selectors:
-                    if selector.get('type') != "TextQuoteSelector":
-                        continue
-                    quote = selector.get("exact")
+            selectors = targets[0].get('selector', [])
+            for selector in selectors:
+                if selector.get('type') != 'TextQuoteSelector':
+                    continue
+                quote = selector.get('exact')
     except KeyError:
         pass
 
+    # If the annotation has no selectors, quote is still None so apply boilerplate
     if quote is None:
-        quote = make_boilerplate_quote(document_uri)
-
-    if text is None:
-        text = make_boilerplate_text()
+        quote = get_boilerplate_quote(document_uri)
 
     if isinstance(document_uri, str) and document_uri.startswith("urn:x-pdf:"):
         try:
@@ -104,13 +116,13 @@ def parse_document(document):
     return {
             "annotation_id": annotation_id,
             "document_uri": document_uri,
-            "can_reveal_metadata": can_reveal_metadata,
-            "quote": quote,
-            "text": text
+            "show_metadata": show_metadata,
+            "quote": _escape_quotes(quote),
+            "text": _escape_quotes(text)
             }
 
 
-def make_pretty_url(url):
+def get_pretty_url(url):
     """
     Return the domain name from `url` for display.
     """
@@ -119,17 +131,19 @@ def make_pretty_url(url):
         pretty_url = parsed_url.netloc[:NETLOC_MAX_LENGTH]
         if len(parsed_url.netloc) > NETLOC_MAX_LENGTH:
             pretty_url = pretty_url + jinja2.Markup("&hellip;")
-    except:
-        return "CannotParseURL"
+    except (ValueError, AttributeError) as e:
+        return None
+
     return pretty_url
 
 
-def make_boilerplate_quote(document_uri):
-    if document_uri is None:
-        return "Hypothesis annotation"
+def get_boilerplate_quote(document_uri):
+    pretty_url = get_pretty_url(document_uri)
+    if pretty_url:
+        return _("Hypothesis annotation for {site}".format(site=pretty_url))
     else:
-        pretty_url = make_pretty_url(document_uri)
-        return "Hypothesis annotation for {site}".format(site=pretty_url)
+        return ANNOTATION_BOILERPLATE_QUOTE
 
-def make_boilerplate_text():
-    return 'Follow this link to see the annotation in context'
+
+def _escape_quotes(string):
+    return string.replace('"', '\u0022').replace("'", '\u0027')

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -11,14 +11,14 @@ _ = i18n.TranslationStringFactory(__package__)
 #: to the user before it gets truncated.
 NETLOC_MAX_LENGTH = 30
 
-# The metadata we are populating has fields that play the roles of Title and
-# Description on Twitter and Facebook share cards. We map the annotation's `quote`
-# field to Title. If we lack a quote we try to form one from `document_uri`
-# If that fails, we fall back to this minimal version.
+#: The metadata we are populating has fields that play the roles of Title and
+#: Description on Twitter and Facebook share cards. We map the annotation's `quote`
+#: field to Title. If we lack a quote we try to form one from `document_uri`
+#: If that fails, we fall back to this minimal version.
 ANNOTATION_BOILERPLATE_QUOTE = _("Hypothesis annotation")
 
-# We map the annotation's `text` field to Description. If it's empty, we fall back
-# to this minimal version.
+#: We map the annotation's `text` field to Description. If it's empty, we fall back
+#: to this minimal version.
 ANNOTATION_BOILERPLATE_TEXT = (
     _('Follow this link to see the annotation in context'))
 
@@ -53,6 +53,10 @@ def parse_document(document):
 
     Also return annotation quote (if available, else empty) and text
     to enhance the share card.
+
+    Tools for checking how FB and Twitter display share metadata:
+      https://developers.facebook.com/tools/debug/sharing/
+      https://cards-dev.twitter.com/validator
 
     :param document: the Elasticsearch annotation document to parse
     :type document: dict

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -74,10 +74,12 @@ class AnnotationController(object):
         pretty_url = _pretty_url(document_uri)
 
         statsd.incr("views.annotation.200.annotation_found")
+        visibility = 'public'
         if ( 'private' in self.request.GET.keys() and 
               self.request.GET['private'] == 'true' ):
-            quote = 'private'
-            text = 'private'
+            visibility = 'private'
+            quote = None
+            text = None
         return {
             "data": json.dumps({
                 # Warning: variable names change from python_style to
@@ -88,7 +90,8 @@ class AnnotationController(object):
             }),
             "pretty_url": pretty_url,
             "quote": quote,
-            "text": text
+            "text": text,
+            "visibility": visibility
         }
 
 

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -15,12 +15,6 @@ from bouncer import __version__ as bouncer_version
 _ = i18n.TranslationStringFactory(__package__)
 
 
-#: The maximum length that the "netloc" (the www.example.com part in
-#: http://www.example.com/example) can be in the pretty URL that is displayed
-#: to the user before it gets truncated.
-NETLOC_MAX_LENGTH = 20
-
-
 class FailedHealthcheck(Exception):
     """An exception raised when the healthcheck fails."""
 
@@ -49,8 +43,7 @@ class AnnotationController(object):
             parsed_document = util.parse_document(document)
             annotation_id = parsed_document["annotation_id"]
             document_uri = parsed_document["document_uri"]
-            group = parsed_document["group"]
-            shared = parsed_document["shared"]
+            can_reveal_metadata = parsed_document["can_reveal_metadata"]
             quote = parsed_document["quote"]
             text = parsed_document["text"]
 
@@ -73,10 +66,15 @@ class AnnotationController(object):
             uri=document_uri,
             id=annotation_id)
 
+        pretty_url = util.make_pretty_url(document_uri)
+
         extension_url = "{uri}#annotations:{id}".format(
             uri=document_uri, id=annotation_id)
 
-        pretty_url = _pretty_url(document_uri)
+        if can_reveal_metadata:
+            title = "Hypothesis annotation for {site}".format(site=pretty_url)
+        else:
+            title = "Hypothesis annotation"
 
         statsd.incr("views.annotation.200.annotation_found")
         return {
@@ -87,11 +85,10 @@ class AnnotationController(object):
                 "viaUrl": via_url,
                 "extensionUrl": extension_url,
             }),
-            "pretty_url": pretty_url,
+            "can_reveal_metadata": can_reveal_metadata,
             "quote": quote,
             "text": text,
-            "shared": shared,
-            "group": group
+            "title": title
         }
 
 

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -58,7 +58,6 @@ class AnnotationController(object):
             statsd.incr("views.annotation.422.{}".format(exc.reason))
             raise httpexceptions.HTTPUnprocessableEntity(str(exc))
 
-
         # Remove any existing #fragment identifier from the URI before we
         # append our own.
         document_uri = parse.urldefrag(document_uri)[0]

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -43,7 +43,7 @@ class AnnotationController(object):
             parsed_document = util.parse_document(document)
             annotation_id = parsed_document["annotation_id"]
             document_uri = parsed_document["document_uri"]
-            can_reveal_metadata = parsed_document["can_reveal_metadata"]
+            show_metadata = parsed_document["show_metadata"]
             quote = parsed_document["quote"]
             text = parsed_document["text"]
 
@@ -71,12 +71,9 @@ class AnnotationController(object):
         extension_url = "{uri}#annotations:{id}".format(
             uri=document_uri, id=annotation_id)
 
-        pretty_url = util.make_pretty_url(document_uri)
+        pretty_url = util.get_pretty_url(document_uri)
 
-        if can_reveal_metadata:
-            title = "Hypothesis annotation for {site}".format(site=pretty_url)
-        else:
-            title = "Hypothesis annotation"
+        title = util.get_boilerplate_quote(document_uri)
 
         statsd.incr("views.annotation.200.annotation_found")
         return {
@@ -87,7 +84,7 @@ class AnnotationController(object):
                 "viaUrl": via_url,
                 "extensionUrl": extension_url,
             }),
-            "can_reveal_metadata": can_reveal_metadata,
+            "show_metadata": show_metadata,
             "quote": quote,
             "text": text,
             "title": title
@@ -138,7 +135,7 @@ def goto_url(request):
     extension_url = '{url}#annotations:query:{query}'.format(
         url=url, query=query)
 
-    pretty_url = util.make_pretty_url(url)
+    pretty_url = util.get_pretty_url(url)
 
     return {
         'data': json.dumps({

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -66,8 +66,6 @@ class AnnotationController(object):
             uri=document_uri,
             id=annotation_id)
 
-        pretty_url = util.make_pretty_url(document_uri)
-
         extension_url = "{uri}#annotations:{id}".format(
             uri=document_uri, id=annotation_id)
 
@@ -85,6 +83,7 @@ class AnnotationController(object):
                 "extensionUrl": extension_url,
             }),
             "show_metadata": show_metadata,
+            "pretty_url": pretty_url,
             "quote": quote,
             "text": text,
             "title": title

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -48,6 +48,7 @@ class AnnotationController(object):
         try:
             annotation_id, document_uri, quote, text \
                 = util.parse_document(document)
+
         except util.InvalidAnnotationError as exc:
             statsd.incr("views.annotation.422.{}".format(exc.reason))
             raise httpexceptions.HTTPUnprocessableEntity(str(exc))
@@ -73,6 +74,10 @@ class AnnotationController(object):
         pretty_url = _pretty_url(document_uri)
 
         statsd.incr("views.annotation.200.annotation_found")
+        if ( 'private' in self.request.GET.keys() and 
+              self.request.GET['private'] == 'true' ):
+            quote = 'private'
+            text = 'private'
         return {
             "data": json.dumps({
                 # Warning: variable names change from python_style to

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -71,6 +71,8 @@ class AnnotationController(object):
         extension_url = "{uri}#annotations:{id}".format(
             uri=document_uri, id=annotation_id)
 
+        pretty_url = util.make_pretty_url(document_uri)
+
         if can_reveal_metadata:
             title = "Hypothesis annotation for {site}".format(site=pretty_url)
         else:
@@ -136,7 +138,7 @@ def goto_url(request):
     extension_url = '{url}#annotations:query:{query}'.format(
         url=url, query=query)
 
-    pretty_url = _pretty_url(url)
+    pretty_url = util.make_pretty_url(url)
 
     return {
         'data': json.dumps({

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -46,7 +46,8 @@ class AnnotationController(object):
             raise httpexceptions.HTTPNotFound(_("Annotation not found"))
 
         try:
-            annotation_id, document_uri = util.parse_document(document)
+            annotation_id, document_uri, quote, text \
+                = util.parse_document(document)
         except util.InvalidAnnotationError as exc:
             statsd.incr("views.annotation.422.{}".format(exc.reason))
             raise httpexceptions.HTTPUnprocessableEntity(str(exc))
@@ -80,7 +81,9 @@ class AnnotationController(object):
                 "viaUrl": via_url,
                 "extensionUrl": extension_url,
             }),
-            "pretty_url": pretty_url
+            "pretty_url": pretty_url,
+            "quote": quote,
+            "text": text
         }
 
 

--- a/tests/bouncer/search_test.py
+++ b/tests/bouncer/search_test.py
@@ -50,7 +50,8 @@ class TestGetClient(object):
                                         use_ssl=True,
                                         verify_certs=True,
                                         ca_certs=certifi.where(),
-                                        connection_class=RequestsHttpConnection)
+                                        connection_class=(
+                                            RequestsHttpConnection))
 
 
 def test_includeme():
@@ -61,4 +62,3 @@ def test_includeme():
     configurator.add_request_method.assert_called_once_with(ANY,
                                                             name='es',
                                                             reify=True)
-

--- a/tests/bouncer/util_test.py
+++ b/tests/bouncer/util_test.py
@@ -7,7 +7,13 @@ def test_parse_document_raises_if_no_uri():
     with pytest.raises(util.InvalidAnnotationError) as exc:
         util.parse_document({
             "_id": "annotation_id",
-            "_source": {}  # No "uri".
+            "_source": {
+                        "target": [{  # no uri
+                                   "selector": []
+                        }],
+            "group": "__world__",
+            "shared": True
+            }
         })
     assert exc.value.reason == "annotation_has_no_uri"
 
@@ -16,7 +22,14 @@ def test_parse_document_raises_if_uri_not_a_string():
     with pytest.raises(util.InvalidAnnotationError) as exc:
         util.parse_document({
             "_id": "annotation_id",
-            "_source": {"target": [{"source": 52}]}  # "uri" isn't a string.
+            "_source": {
+                        "target": [{
+                                    "source": 52, # "uri" isn't a string.
+                                    "selector": []
+                        }],
+            "group": "__world__",
+            "shared": True
+            }
         })
     assert exc.value.reason == "uri_not_a_string"
 
@@ -24,8 +37,15 @@ def test_parse_document_raises_if_uri_not_a_string():
 def test_parse_document_returns_annotation_id():
     annotation_id = util.parse_document({
         "_id": "annotation_id",
-        "_source": {"target": [{"source": "http://example.com/example.html"}]}
-    })[0]
+        "_source": {
+                    "target": [{
+                                "source": "http://example.com/example.html",
+                                "selector": [],
+                    }],
+        "group": "__world__",
+        "shared": True
+        }
+    })["annotation_id"]
 
     assert annotation_id == "annotation_id"
 
@@ -33,20 +53,134 @@ def test_parse_document_returns_annotation_id():
 def test_parse_document_returns_document_uri():
     document_uri = util.parse_document({
         "_id": "annotation_id",
-        "_source": {"target": [{"source": "http://example.com/example.html"}]}
-    })[1]
+        "_source": {
+                    "target": [{
+                                "source": "http://example.com/example.html",
+                                "selector": []
+                    }],
+        "group": "__world__",
+        "shared": True
+        }
+    })["document_uri"]
 
     assert document_uri == "http://example.com/example.html"
+
+
+def test_parse_document_returns_quote():
+    quote = util.parse_document({
+        "_id": "annotation_id",
+        "_source": {
+                    "target": [{
+                                "source": "http://example.com/example.html",
+                                "selector": [{
+                                                "type": "TextQuoteSelector",
+                                                "exact": "test_quote"
+                                }]
+                    }],
+        "group": "__world__",
+        "shared": True
+        }
+    })["quote"]
+
+    assert quote == "test_quote"
+
+
+def test_parse_document_returns_boilerplate_when_no_quote():
+    parsed_document = util.parse_document({
+        "_id": "annotation_id",
+        "_source": {
+                    "target": [{
+                                "source": "http://example.com/example.html",
+                                "selector": []
+                    }],
+        "group": "__world__",
+        "shared": True
+        }
+    })
+    quote = parsed_document["quote"]
+    document_uri = parsed_document["document_uri"]
+
+    assert quote == "Annotation for {}".format(document_uri)
+
+
+def test_parse_document_returns_text():
+    text = util.parse_document({
+        "_id": "annotation_id",
+        "_source": {
+                    "target": [{
+                                "source": "http://example.com/example.html",
+                                "selector": [{}]
+                    }],
+        "group": "__world__",
+        "shared": True,
+        "text": "test_text"
+        }
+    })["text"]
+
+    assert text == "test_text"
+
+
+def test_parse_document_returns_boilerplate_when_no_text():
+    text = util.parse_document({
+        "_id": "annotation_id",
+        "_source": {
+                    "target": [{
+                                "source": "http://example.com/example.html",
+                                "selector": [{}]
+                    }],
+        "group": "__world__",
+        "shared": True
+        }
+    })["text"]
+
+    assert text == "Follow this link to see the annotation on the original page." 
+
+
+def test_parse_document_returns_shared():
+    shared = util.parse_document({
+        "_id": "annotation_id",
+        "_source": {
+                    "target": [{
+                                "source": "http://example.com/example.html",
+                                "selector": [{}]
+                    }],
+        "group": "__world__",
+        "shared": True
+        }
+    })["shared"]
+
+    assert shared == True
+
+
+def test_parse_document_returns_group():
+    group = util.parse_document({
+        "_id": "annotation_id",
+        "_source": {
+                    "target": [{
+                                "source": "http://example.com/example.html",
+                                "selector": [{}]
+                    }],
+        "group": "__world__",
+        "shared": True
+        }
+    })["group"]
+
+    assert group == "__world__"
 
 
 def test_parse_document_returns_document_uri_from_web_uri_when_pdf():
     document_uri = util.parse_document({
         "_id": "annotation_id",
         "_source": {
-            "target": [{"source": "urn:x-pdf:the-fingerprint"}],
-            "document": {"web_uri": "http://example.com/foo.pdf"}
+            "target": [{
+                        "source": "urn:x-pdf:the-fingerprint",
+                        "selector": []
+            }],
+        "group": "__world__",
+        "shared": True,
+        "document": {"web_uri": "http://example.com/foo.pdf"}
         }
-    })[1]
+    })["document_uri"]
 
     assert document_uri == "http://example.com/foo.pdf"
 
@@ -56,8 +190,13 @@ def test_parse_document_raises_when_uri_from_web_uri_not_string_for_pdfs():
         util.parse_document({
             "_id": "annotation_id",
             "_source": {
-                "target": [{"source": "urn:x-pdf:the-fingerprint"}],
-                "document": {"web_uri": 52}
+                "target": [{
+                            "source": "urn:x-pdf:the-fingerprint",
+                            "selector": []
+                }],
+            "group": "__world__",
+            "shared": True,
+            "document": {"web_uri": 52}
             }
         })
     assert exc.value.reason == "uri_not_a_string"

--- a/tests/bouncer/util_test.py
+++ b/tests/bouncer/util_test.py
@@ -8,11 +8,11 @@ def test_parse_document_raises_if_no_uri():
         util.parse_document({
             "_id": "annotation_id",
             "_source": {
-                        "target": [{  # no uri
-                                   "selector": []
-                        }],
-            "group": "__world__",
-            "shared": True
+                "target": [{  # no uri
+                            "selector": []
+                            }],
+                "group": "__world__",
+                "shared": True
             }
         })
     assert exc.value.reason == "annotation_has_no_uri"
@@ -23,12 +23,12 @@ def test_parse_document_raises_if_uri_not_a_string():
         util.parse_document({
             "_id": "annotation_id",
             "_source": {
-                        "target": [{
-                                    "source": 52, # "uri" isn't a string.
-                                    "selector": []
-                        }],
-            "group": "__world__",
-            "shared": True
+                "target": [{
+                            "source": 52,  # "uri" isn't a string.
+                            "selector": []
+                            }],
+                "group": "__world__",
+                "shared": True
             }
         })
     assert exc.value.reason == "uri_not_a_string"
@@ -38,12 +38,12 @@ def test_parse_document_returns_annotation_id():
     annotation_id = util.parse_document({
         "_id": "annotation_id",
         "_source": {
-                    "target": [{
-                                "source": "http://example.com/example.html",
-                                "selector": [],
-                    }],
-        "group": "__world__",
-        "shared": True
+            "target": [{
+                "source": "http://example.com/example.html",
+                "selector": [],
+            }],
+            "group": "__world__",
+            "shared": True
         }
     })["annotation_id"]
 
@@ -54,12 +54,12 @@ def test_parse_document_returns_document_uri():
     document_uri = util.parse_document({
         "_id": "annotation_id",
         "_source": {
-                    "target": [{
-                                "source": "http://example.com/example.html",
-                                "selector": []
-                    }],
-        "group": "__world__",
-        "shared": True
+            "target": [{
+                "source": "http://example.com/example.html",
+                "selector": []
+            }],
+            "group": "__world__",
+            "shared": True
         }
     })["document_uri"]
 
@@ -70,15 +70,15 @@ def test_parse_document_returns_quote():
     quote = util.parse_document({
         "_id": "annotation_id",
         "_source": {
-                    "target": [{
+            "target": [{
                                 "source": "http://example.com/example.html",
                                 "selector": [{
-                                                "type": "TextQuoteSelector",
-                                                "exact": "test_quote"
+                                    "type": "TextQuoteSelector",
+                                    "exact": "test_quote"
                                 }]
-                    }],
-        "group": "__world__",
-        "shared": True
+                                }],
+            "group": "__world__",
+            "shared": True
         }
     })["quote"]
 
@@ -89,12 +89,12 @@ def test_parse_document_returns_boilerplate_when_no_quote():
     parsed_document = util.parse_document({
         "_id": "annotation_id",
         "_source": {
-                    "target": [{
-                                "source": "http://example.com/example.html",
-                                "selector": []
-                    }],
-        "group": "__world__",
-        "shared": True
+            "target": [{
+                "source": "http://example.com/example.html",
+                "selector": []
+            }],
+            "group": "__world__",
+            "shared": True
         }
     })
     quote = parsed_document["quote"]
@@ -107,13 +107,13 @@ def test_parse_document_returns_text():
     text = util.parse_document({
         "_id": "annotation_id",
         "_source": {
-                    "target": [{
-                                "source": "http://example.com/example.html",
-                                "selector": [{}]
-                    }],
-        "group": "__world__",
-        "shared": True,
-        "text": "test_text"
+            "target": [{
+                "source": "http://example.com/example.html",
+                "selector": [{}]
+            }],
+            "group": "__world__",
+            "shared": True,
+            "text": "test_text"
         }
     })["text"]
 
@@ -124,44 +124,45 @@ def test_parse_document_returns_boilerplate_when_no_text():
     text = util.parse_document({
         "_id": "annotation_id",
         "_source": {
-                    "target": [{
-                                "source": "http://example.com/example.html",
-                                "selector": [{}]
-                    }],
-        "group": "__world__",
-        "shared": True
+            "target": [{
+                "source": "http://example.com/example.html",
+                "selector": [{}]
+            }],
+            "group": "__world__",
+            "shared": True
         }
     })["text"]
 
-    assert text == "Follow this link to see the annotation on the original page." 
+    assert text == (
+        "Follow this link to see the annotation on the original page.")
 
 
 def test_parse_document_returns_shared():
     shared = util.parse_document({
         "_id": "annotation_id",
         "_source": {
-                    "target": [{
-                                "source": "http://example.com/example.html",
-                                "selector": [{}]
-                    }],
-        "group": "__world__",
-        "shared": True
+            "target": [{
+                "source": "http://example.com/example.html",
+                "selector": [{}]
+            }],
+            "group": "__world__",
+            "shared": True
         }
     })["shared"]
 
-    assert shared == True
+    assert shared is True
 
 
 def test_parse_document_returns_group():
     group = util.parse_document({
         "_id": "annotation_id",
         "_source": {
-                    "target": [{
+            "target": [{
                                 "source": "http://example.com/example.html",
                                 "selector": [{}]
-                    }],
-        "group": "__world__",
-        "shared": True
+                                }],
+            "group": "__world__",
+            "shared": True
         }
     })["group"]
 
@@ -173,12 +174,12 @@ def test_parse_document_returns_document_uri_from_web_uri_when_pdf():
         "_id": "annotation_id",
         "_source": {
             "target": [{
-                        "source": "urn:x-pdf:the-fingerprint",
-                        "selector": []
+                "source": "urn:x-pdf:the-fingerprint",
+                "selector": []
             }],
-        "group": "__world__",
-        "shared": True,
-        "document": {"web_uri": "http://example.com/foo.pdf"}
+            "group": "__world__",
+            "shared": True,
+            "document": {"web_uri": "http://example.com/foo.pdf"}
         }
     })["document_uri"]
 
@@ -193,10 +194,10 @@ def test_parse_document_raises_when_uri_from_web_uri_not_string_for_pdfs():
                 "target": [{
                             "source": "urn:x-pdf:the-fingerprint",
                             "selector": []
-                }],
-            "group": "__world__",
-            "shared": True,
-            "document": {"web_uri": 52}
+                            }],
+                "group": "__world__",
+                "shared": True,
+                "document": {"web_uri": 52}
             }
         })
     assert exc.value.reason == "uri_not_a_string"

--- a/tests/bouncer/util_test.py
+++ b/tests/bouncer/util_test.py
@@ -137,6 +137,7 @@ def test_parse_document_returns_boilerplate_when_no_text():
 
     assert text == util.make_boilerplate_text()
 
+
 def test_parse_document_returns_can_reveal_true_when_shared_and_world():
     can_reveal_metadata = util.parse_document({
         "_id": "annotation_id",

--- a/tests/bouncer/util_test.py
+++ b/tests/bouncer/util_test.py
@@ -67,7 +67,7 @@ def test_parse_document_returns_document_uri():
 
 
 def test_parse_document_returns_quote():
-    quote = util.parse_document({
+    parsed_document = util.parse_document({
         "_id": "annotation_id",
         "_source": {
             "target": [{
@@ -80,7 +80,8 @@ def test_parse_document_returns_quote():
             "group": "__world__",
             "shared": True
         }
-    })["quote"]
+    })
+    quote = parsed_document["quote"]
 
     assert quote == "test_quote"
 
@@ -100,7 +101,7 @@ def test_parse_document_returns_boilerplate_when_no_quote():
     quote = parsed_document["quote"]
     document_uri = parsed_document["document_uri"]
 
-    assert quote == "Annotation for {}".format(document_uri)
+    assert quote == util.make_boilerplate_quote(document_uri)
 
 
 def test_parse_document_returns_text():
@@ -129,16 +130,15 @@ def test_parse_document_returns_boilerplate_when_no_text():
                 "selector": [{}]
             }],
             "group": "__world__",
-            "shared": True
+            "shared": True,
+            "text": ""
         }
     })["text"]
 
-    assert text == (
-        "Follow this link to see the annotation on the original page.")
+    assert text == util.make_boilerplate_text()
 
-
-def test_parse_document_returns_shared():
-    shared = util.parse_document({
+def test_parse_document_returns_can_reveal_true_when_shared_and_world():
+    can_reveal_metadata = util.parse_document({
         "_id": "annotation_id",
         "_source": {
             "target": [{
@@ -148,25 +148,9 @@ def test_parse_document_returns_shared():
             "group": "__world__",
             "shared": True
         }
-    })["shared"]
+    })["can_reveal_metadata"]
 
-    assert shared is True
-
-
-def test_parse_document_returns_group():
-    group = util.parse_document({
-        "_id": "annotation_id",
-        "_source": {
-            "target": [{
-                                "source": "http://example.com/example.html",
-                                "selector": [{}]
-                                }],
-            "group": "__world__",
-            "shared": True
-        }
-    })["group"]
-
-    assert group == "__world__"
+    assert can_reveal_metadata == True
 
 
 def test_parse_document_returns_document_uri_from_web_uri_when_pdf():

--- a/tests/bouncer/util_test.py
+++ b/tests/bouncer/util_test.py
@@ -86,22 +86,20 @@ def test_parse_document_returns_quote():
     assert quote == "test_quote"
 
 
-def test_parse_document_returns_boilerplate_when_no_quote():
+def test_parse_document_returns_boilerplate_quote_when_no_quote():
     parsed_document = util.parse_document({
         "_id": "annotation_id",
         "_source": {
             "target": [{
-                "source": "http://example.com/example.html",
-                "selector": []
-            }],
+                                "source": "http://example.com/example.html",
+                                }],
             "group": "__world__",
             "shared": True
         }
     })
     quote = parsed_document["quote"]
-    document_uri = parsed_document["document_uri"]
 
-    assert quote == util.make_boilerplate_quote(document_uri)
+    assert quote == "Hypothesis annotation for example.com"
 
 
 def test_parse_document_returns_text():
@@ -135,11 +133,11 @@ def test_parse_document_returns_boilerplate_when_no_text():
         }
     })["text"]
 
-    assert text == util.make_boilerplate_text()
+    assert text == util.ANNOTATION_BOILERPLATE_TEXT
 
 
-def test_parse_document_returns_can_reveal_true_when_shared_and_world():
-    can_reveal_metadata = util.parse_document({
+def test_parse_document_returns_show_metadata_true_when_shared_and_world():
+    show_metadata = util.parse_document({
         "_id": "annotation_id",
         "_source": {
             "target": [{
@@ -149,9 +147,9 @@ def test_parse_document_returns_can_reveal_true_when_shared_and_world():
             "group": "__world__",
             "shared": True
         }
-    })["can_reveal_metadata"]
+    })["show_metadata"]
 
-    assert can_reveal_metadata == True
+    assert show_metadata is True
 
 
 def test_parse_document_returns_document_uri_from_web_uri_when_pdf():

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -321,7 +321,8 @@ def parse_document(request):
     parse_document = patcher.start()
     request.addfinalizer(patcher.stop)
     parse_document.return_value = [
-        "AVLlVTs1f9G3pW-EYc6q", "http://www.example.com/example.html"]
+        "AVLlVTs1f9G3pW-EYc6q", "http://www.example.com/example.html",
+        "sample quote", "sample text"]
     return parse_document
 
 
@@ -346,7 +347,9 @@ def mock_request():
     request.es = mock.Mock()
     request.es.get.return_value = {
         "_id": "AVLlVTs1f9G3pW-EYc6q",
-        "_source": {"uri": "http://www.example.com/example.html"}
+        "_source": {"uri": "http://www.example.com/example.html"},
+        "quote": "sample quote",
+        "text": "sample text"
     }
     request.raven = mock.Mock()
     return request

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -326,7 +326,7 @@ def parse_document(request):
     parse_document.return_value = {
         "annotation_id": "AVLlVTs1f9G3pW-EYc6q",
         "document_uri": "http://www.example.com/example.html",
-        "can_reveal_metadata": True,
+        "show_metadata": True,
         "quote": "Hypothesis annotation for www.example.com",
         "text": "test_text"
     }

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -24,7 +24,8 @@ class TestAnnotationController(object):
             id="AVLlVTs1f9G3pW-EYc6q"
         )
 
-    def test_annotation_increments_stat_if_get_raises_NotFoundError(self, statsd):
+    def test_annotation_increments_stat_if_get_raises_not_found_error(self,
+                                                                      statsd):
         request = mock_request()
         request.es.get.side_effect = es_exceptions.NotFoundError
 
@@ -36,7 +37,7 @@ class TestAnnotationController(object):
         statsd.incr.assert_called_once_with(
             "views.annotation.404.annotation_not_found")
 
-    def test_annotation_raises_HTTPNotFound_if_get_raises_NotFoundError(self):
+    def test_annotation_raises_http_not_found_if_get_raises_not_found_error(self):
         request = mock_request()
         request.es.get.side_effect = es_exceptions.NotFoundError
 
@@ -50,9 +51,9 @@ class TestAnnotationController(object):
 
         parse_document.assert_called_once_with(request.es.get.return_value)
 
-    def test_annotation_increments_stat_if_parse_document_raises(self,
-                                                                 parse_document,
-                                                                 statsd):
+    def test_annotation_bumps_stat_if_parse_document_raises(self,
+                                                            parse_document,
+                                                            statsd):
         parse_document.side_effect = util.InvalidAnnotationError(
             "error message", "the_reason")
 
@@ -71,9 +72,10 @@ class TestAnnotationController(object):
             views.AnnotationController(mock_request()).annotation()
         assert str(exc.value) == "error message"
 
-    def test_annotation_increments_stat_for_file_URLs(
+    def test_annotation_increments_stat_for_file_urls(
             self, parse_document, statsd):
-        parse_document.return_value["document_uri"] = "file:///home/seanh/Foo.pdf"
+        parse_document.return_value["document_uri"] = (
+            "file:///home/seanh/Foo.pdf")
 
         try:
             views.AnnotationController(mock_request()).annotation()
@@ -83,9 +85,10 @@ class TestAnnotationController(object):
         statsd.incr.assert_called_once_with(
             "views.annotation.422.not_an_http_or_https_document")
 
-    def test_annotation_raises_HTTPUnprocessableEntity_for_file_URLs(
+    def test_annotation_raises_http_unprocessable_entity_for_file_urls(
             self, parse_document):
-        parse_document.return_value["document_uri"] = "file:///home/seanh/Foo.pdf"
+        parse_document.return_value["document_uri"] = (
+            "file:///home/seanh/Foo.pdf")
 
         with pytest.raises(httpexceptions.HTTPUnprocessableEntity):
             views.AnnotationController(mock_request()).annotation()
@@ -97,20 +100,23 @@ class TestAnnotationController(object):
             "views.annotation.200.annotation_found")
 
     def test_annotation_returns_chrome_extension_id(self):
-        template_data = views.AnnotationController(mock_request()).annotation()
+        template_data = (
+            views.AnnotationController(mock_request()).annotation())
 
         data = json.loads(template_data["data"])
         assert data["chromeExtensionId"] == "test-extension-id"
 
     def test_annotation_returns_via_url(self):
-        template_data = views.AnnotationController(mock_request()).annotation()
+        template_data = (
+            views.AnnotationController(mock_request()).annotation())
 
         data = json.loads(template_data["data"])
         assert data["viaUrl"] == (
                 "https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
 
     def test_annotation_returns_extension_url(self):
-        template_data = views.AnnotationController(mock_request()).annotation()
+        template_data = (
+            views.AnnotationController(mock_request()).annotation())
 
         data = json.loads(template_data["data"])
         assert data["extensionUrl"] == (
@@ -119,7 +125,8 @@ class TestAnnotationController(object):
     def test_annotation_strips_fragment_identifiers(self, parse_document):
         parse_document.return_value["document_uri"] = (
             "http://example.com/example.html#foobar")
-        template_data = views.AnnotationController(mock_request()).annotation()
+        template_data = (
+            views.AnnotationController(mock_request()).annotation())
 
         data = json.loads(template_data["data"])
 
@@ -129,8 +136,10 @@ class TestAnnotationController(object):
                 "https://via.hypothes.is/http://example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
 
     def test_annotation_strips_bare_fragment_identifiers(self, parse_document):
-        parse_document.return_value["document_uri"] = "http://example.com/example.html#"
-        template_data = views.AnnotationController(mock_request()).annotation()
+        parse_document.return_value["document_uri"] = (
+           "http://example.com/example.html#")
+        template_data = (
+            views.AnnotationController(mock_request()).annotation())
 
         data = json.loads(template_data["data"])
 
@@ -140,7 +149,8 @@ class TestAnnotationController(object):
                 "https://via.hypothes.is/http://example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
 
     def test_annotation_returns_pretty_url(self):
-        template_data = views.AnnotationController(mock_request()).annotation()
+        template_data = (
+            views.AnnotationController(mock_request()).annotation())
 
         assert template_data["pretty_url"] == "www.example.com"
 
@@ -148,7 +158,8 @@ class TestAnnotationController(object):
         parse_document.return_value["document_uri"] = (
             "http://www.abcdefghijklmnopqrst.com/example.html")
 
-        template_data = views.AnnotationController(mock_request()).annotation()
+        template_data = (
+            views.AnnotationController(mock_request()).annotation())
 
         assert template_data["pretty_url"] == "www.abcdefghijklmnop&hellip;"
 

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -73,7 +73,7 @@ class TestAnnotationController(object):
 
     def test_annotation_increments_stat_for_file_URLs(
             self, parse_document, statsd):
-        parse_document.return_value[1] = "file:///home/seanh/Foo.pdf"
+        parse_document.return_value["document_uri"] = "file:///home/seanh/Foo.pdf"
 
         try:
             views.AnnotationController(mock_request()).annotation()
@@ -85,7 +85,7 @@ class TestAnnotationController(object):
 
     def test_annotation_raises_HTTPUnprocessableEntity_for_file_URLs(
             self, parse_document):
-        parse_document.return_value[1] = "file:///home/seanh/Foo.pdf"
+        parse_document.return_value["document_uri"] = "file:///home/seanh/Foo.pdf"
 
         with pytest.raises(httpexceptions.HTTPUnprocessableEntity):
             views.AnnotationController(mock_request()).annotation()
@@ -117,7 +117,7 @@ class TestAnnotationController(object):
                 "http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
 
     def test_annotation_strips_fragment_identifiers(self, parse_document):
-        parse_document.return_value[1] = (
+        parse_document.return_value["document_uri"] = (
             "http://example.com/example.html#foobar")
         template_data = views.AnnotationController(mock_request()).annotation()
 
@@ -129,7 +129,7 @@ class TestAnnotationController(object):
                 "https://via.hypothes.is/http://example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
 
     def test_annotation_strips_bare_fragment_identifiers(self, parse_document):
-        parse_document.return_value[1] = "http://example.com/example.html#"
+        parse_document.return_value["document_uri"] = "http://example.com/example.html#"
         template_data = views.AnnotationController(mock_request()).annotation()
 
         data = json.loads(template_data["data"])
@@ -145,7 +145,7 @@ class TestAnnotationController(object):
         assert template_data["pretty_url"] == "www.example.com"
 
     def test_annotation_truncates_pretty_url(self, parse_document):
-        parse_document.return_value[1] = (
+        parse_document.return_value["document_uri"] = (
             "http://www.abcdefghijklmnopqrst.com/example.html")
 
         template_data = views.AnnotationController(mock_request()).annotation()
@@ -320,9 +320,14 @@ def parse_document(request):
     patcher = mock.patch("bouncer.views.util.parse_document")
     parse_document = patcher.start()
     request.addfinalizer(patcher.stop)
-    parse_document.return_value = [
-        "AVLlVTs1f9G3pW-EYc6q", "http://www.example.com/example.html",
-        "sample quote", "sample text"]
+    parse_document.return_value = {
+        "annotation_id": "AVLlVTs1f9G3pW-EYc6q",
+        "document_uri": "http://www.example.com/example.html",
+        "group": "__world__",
+        "shared": True,
+        "quote": "test_quote",
+        "text": "test_text"
+    }
     return parse_document
 
 
@@ -345,11 +350,17 @@ def mock_request():
                                  "via_base_url": "https://via.hypothes.is"}
     request.matchdict = {"id": "AVLlVTs1f9G3pW-EYc6q"}
     request.es = mock.Mock()
+
     request.es.get.return_value = {
         "_id": "AVLlVTs1f9G3pW-EYc6q",
-        "_source": {"uri": "http://www.example.com/example.html"},
-        "quote": "sample quote",
-        "text": "sample text"
+        "_source": {
+            "target": [{
+                "source": "http://example.com/example.html",
+                "selector": [],
+            }],
+            "uri": "http://www.example.com/example.html",
+            "group": "__world__"
+        }
     }
     request.raven = mock.Mock()
     return request


### PR DESCRIPTION
# sample results

![image](https://cloud.githubusercontent.com/assets/46509/26604393/19433a60-453f-11e7-8366-68ef2db7ec87.png)

# see also

https://docs.google.com/document/d/1UPPPgLLPMTwxh83BITCiSK7QxfwpORONiZF9vFL4doA

# notes

these flake8 complaints were for the pre-existing HEAD (ce16736e40222dc0caab041f07ac2c6a53e4ed35)

```
./views.py:75:11: E111 indentation is not a multiple of four
./views.py:140:64: E999 SyntaxError: invalid syntax
./__init__.py:45:80: E501 line too long (97 > 79 characters)
./__init__.py:47:80: E501 line too long (105 > 79 characters)
./__init__.py:49:80: E501 line too long (83 > 79 characters)
./_version.py:62:44: F821 undefined name 'FileNotFoundError'
```
