### PR TITLE
Expose bouncer version in /_status endpoint

### DIFF
--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -9,6 +9,7 @@ from pyramid import view
 from statsd.defaults.env import statsd
 
 from bouncer import util
+from bouncer import __version__ as bouncer_version
 
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -140,7 +141,7 @@ def healthcheck(request):
         raise FailedHealthcheck('elasticsearch exception') from exc
     if status not in ('yellow', 'green'):
         raise FailedHealthcheck('cluster status was {!r}'.format(status))
-    return {'status': 'ok'}
+    return {'status': 'ok', 'version': bouncer_version}
 
 
 def includeme(config):

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -225,7 +225,8 @@ class TestHealthcheck(object):
 
         result = views.healthcheck(request)
 
-        assert result == {'status': 'ok'}
+        assert 'status' in result
+        assert result['status'] == 'ok'
 
     def test_failed_es_request(self):
         request = mock_request()


### PR DESCRIPTION
This can aid in debugging to easily know which version we're currently
running.