### PR TITLE
Add `/go` endpoint for visiting a URL with annotations.

### DIFF
--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -109,14 +109,14 @@ def goto_url(request):
     if url is None:
         raise httpexceptions.HTTPBadRequest('"url" parameter is missing')
 
-    # Remove any existing #fragment identifier from the URI before we
-    # append our own.
-    url = parse.urldefrag(url)[0]
-
     if not _is_http_url(url):
         raise httpexceptions.HTTPBadRequest(
             _('Sorry, but this service can only show annotations on '
               'HTTP URLs.'))
+
+    # Remove any existing #fragment identifier from the URI before we
+    # append our own.
+    url = parse.urldefrag(url)[0]
 
     query = parse.quote(request.params.get('q', ''))
 

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -197,9 +197,16 @@ class TestGotoUrlController(object):
         assert data['viaUrl'].endswith(expected_frag)
         assert data['extensionUrl'].endswith(expected_frag)
 
-    def test_it_validates_url(self):
-        invalid_urls = [None, 'ftp://foo.bar', 'doi:10.1.2/345',
-                        'file://foo.bar']
+    def test_it_rejects_invalid_or_missing_urls(self):
+        invalid_urls = [None,
+
+                        # Unsupported protocols.
+                        'ftp://foo.bar',
+                        'doi:10.1.2/345',
+                        'file://foo.bar',
+
+                        # Malformed URLs.
+                        'http://goo\[g']
 
         for url in invalid_urls:
             request = mock_request()
@@ -207,6 +214,18 @@ class TestGotoUrlController(object):
 
             with pytest.raises(httpexceptions.HTTPBadRequest):
                 views.goto_url(request)
+
+    def test_it_allows_valid_http_urls(self):
+        valid_urls = ['http://publisher.org',
+                      'https://publisher.org',
+                      'HTTP://PUBLISHER.ORG',
+                      'HTTPS://example.com']
+
+        for url in valid_urls:
+            request = mock_request()
+            request.GET['url'] = url
+
+            views.goto_url(request)
 
     def test_it_strips_existing_fragment(self):
         request = mock_request()


### PR DESCRIPTION
Add a `/go?url={url}` endpoint which takes the user to a given URL with
the annotation layer enabled, optionally with the client configured to
initially show only annotations matching a given filter by specifying a
"q={query}" parameter.

The {query} is passed directly to the search input in the client.

For the API design rationale and discussion, see [1] and [2].

[1] https://gist.github.com/robertknight/85c9dfc89910288e84588903ab1010a3

[2] https://groups.google.com/a/list.hypothes.is/forum/#!topic/dev/sFH-3xmeK8Y

----

**Testing**

1. Visit https://BOUNCER.URL/go?url=https://example.com
2. This should open "example.com" in Via with the annotation layer enabled. Note that the sidebar does not automatically open if no query is supplied.
3. Visit https://BOUNCER.URL/go?url=https://example.com&q=robertknight
4. This should open "example.com" in Via, open the sidebar and show annotations written by or containing the string "robertknight".

Common queries would be "user:a_username" or "tag:a_tag", but be aware that there is a bug in the client where it does not correctly decode reserved URL chars (eg. ":", "/") in the query, so a query such as "user:robertknight" ends up populating the client's search input with "user%3Arobertknight". This is fixed by https://github.com/hypothesis/client/pull/483