### PR TITLE
Update JS dev dependencies

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: false,
-    browsers: ['PhantomJS2'],
+    browsers: ['PhantomJS'],
     singleRun: true,
     concurrency: Infinity
   });

--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
   "devDependencies": {
-    "browserify": "^13.0.0",
-    "chai": "^3.5.0",
+    "browserify": "^14.4.0",
+    "chai": "^4.0.2",
     "jscs": "^1.13.1",
     "jshint": "^2.9.1",
-    "karma": "^0.13.21",
-    "karma-browserify": "^4.4.2",
+    "karma": "^1.7.0",
+    "karma-browserify": "^5.1.1",
     "karma-chai": "^0.1.0",
-    "karma-mocha": "^0.2.2",
-    "karma-phantomjs2-launcher": "^0.5.0",
+    "karma-mocha": "^1.3.0",
+    "karma-phantomjs-launcher": "^1.0.4",
     "karma-sinon": "^1.0.4",
-    "mocha": "^2.4.5",
-    "sinon": "^1.17.3"
+    "mocha": "^3.4.2",
+    "sinon": "^2.3.6",
+    "watchify": "^3.9.0"
   },
   "license": "BSD-2-Clause",
   "repository": {


### PR DESCRIPTION
Update JS dev dependencies to latest versions to fix the many
deprecation warnings during package installation.

"watchify" was added because karma-browserify now requires it as a peer
dependency.

"karma-phantomjs2-launcher" was replaced with "karma-phantomjs-launcher" because the latter now does use PhantomJS v2 and the former recommends this change during package installation.