### PR TITLE
Don't pass --parallel to coverage run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ deps =
     mock
     pytest
     -r{toxinidir}/requirements.txt
-commands = coverage run --parallel --source bouncer,tests/bouncer -m pytest {posargs:tests/bouncer/}
+commands = coverage run --source bouncer,tests/bouncer -m pytest {posargs:tests/bouncer/}


### PR DESCRIPTION
This should fix coverage reporting on codecov, which hasn't been working
for 7 months.

--parallel causes coverage to generate output files named like
.coverage.$HOSTNAME.8089.232834 which codecov is unable to find. You
need to combine those into a single .coverage file by running coverage
combine.

Since we're not actually running more than one coverage task at once
--parallel is pointless, and if you remove it then coverage just
generates the one .coverage file that codecov should be able to find in
the first place.