### PR TITLE
Clean up travis, tox and make files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .coverage.*
 .cache
 .tox
+.pydeps
 
 node_modules
 bouncer/static/scripts/bundle.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ env:
   - NODE_VERSION="6.9"
 before_install:
   - nvm install $NODE_VERSION
-  - pip install codecov
-install:
-  - make deps
 script:
   - make test
 after_success:
-  - codecov
+  - make codecov

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,57 @@
-DOCKER_TAG = dev
-
-deps:
-	pip install --upgrade pip
-	pip install --upgrade wheel
-	pip install --use-wheel -r requirements-dev.txt
-	npm install
-
-dev:
+# Run the development web server.
+.PHONY: dev
+dev: .pydeps node_modules/.uptodate
 	PYRAMID_RELOAD_TEMPLATES=1 gunicorn --reload "bouncer.app:app()"
 
+# Run all the tests (Python and JavaScript).
 .PHONY: test
-test:
-	@pip install -q tox
-	tox
+test: node_modules/.uptodate pytests
 	./node_modules/.bin/eslint bouncer/scripts
 	./node_modules/karma/bin/karma start karma.config.js
 
+# Run the tests and then print out a coverage report.
+# `make coverage` always re-runs the tests.
+.PHONY: coverage
+coverage: test tox
+	tox -e coverage
+
+# Send a coverage report to Codecov based on the existing .coverage file.
+# The Python tests will be run to generate the .coverage file if it doesn't
+# exist, but if the .coverage file is out of date (code has changed) the tests
+# won't be re-run.
+.PHONY: codecov
+codecov: .coverage tox
+	tox -e codecov
+
+# Build the docker image.
 .PHONY: docker
 docker:
-	git archive HEAD | docker build -t hypothesis/bouncer:$(DOCKER_TAG) -
+	git archive HEAD | docker build -t hypothesis/bouncer:dev -
 
 .PHONY: clean
 clean:
 	find . -type f -name "*.py[co]" -delete
 	find . -type d -name "__pycache__" -delete
-	rm -f node_modules/.uptodate
+	-rm -f .pydeps node_modules/.uptodate .coverage
+
+.pydeps: requirements-dev.txt requirements.txt
+	pip install --upgrade pip
+	pip install --upgrade wheel
+	pip install --use-wheel -r requirements-dev.txt
+	touch .pydeps
+
+node_modules/.uptodate: package.json
+	npm install
+	touch node_modules/.uptodate
+
+.coverage:
+	$(MAKE) tox
+	tox
+
+.PHONY: pytests
+pytests: tox
+	tox
+
+.PHONY: tox
+tox:
+	pip install -q tox

--- a/tox.ini
+++ b/tox.ini
@@ -17,3 +17,23 @@ deps =
     pytest
     -r{toxinidir}/requirements.txt
 commands = coverage run --source bouncer,tests/bouncer -m pytest {posargs:tests/bouncer/}
+
+[testenv:clean]
+deps = coverage
+commands = coverage erase
+
+# `tox -e coverage` prints out the coverage report to the terminal.
+# You have to run `tox` on its own (the default testenv above) to generate the
+# .coverage file first.
+[testenv:coverage]
+deps = coverage
+commands =
+    coverage report
+
+# `tox -e codecov` uploads the coverage report to Codecov.
+# You have to run `tox` on its own (the default testenv above) to generate the
+# .coverage file first.
+[testenv:codecov]
+deps = codecov
+passenv = CI TRAVIS*
+commands = codecov


### PR DESCRIPTION
Everything is done via the make command:

- make dev (or just `make`)
- make test
- make coverage
- make codecov
- make docker
- The .travis.yml file just runs make deps, test, coverage and codecov.
- The Jenkinsfile still runs pip and tox directly though, because make
  isn't installed on the Jenkins server

And everything that can be is run inside the tox-managed virtualenv:

- make test runs the tests inside tox (for the Python tests, at least)
- make coverage runs coverage report inside tox
- make codecov runs codecov inside tox

All dependency specifications are moved out of the `Makefile`:

- Python dependencies needed only be tox are configured in the tox.ini file.

- Python dependencies needed by both tox (e.g. `make test`) and the dev
  server (`make dev`) are specified in `requirements-dev.txt`.

- JavaScript dependencies (both for `make dev` and `make test`) are
  specified in `package.json`.

- The only dependency that needs to be specified in the `Makefile` is
  `tox` itself (and this dependency specification has been deduplicated).

Finally, `make coverage` and `make codecov` will run the Python tests to
generate the `.coverage` file if it doesn't exist. If the `.coverage`
file does exist then `make coverage codecov` _won't_ re-run the tests,
which is the behaviour that our `.travis.yml` file wants.

Note however that `make coverage codecov` also won't automatically
re-run the Python tests if the Python code has changed - you have to run
`make test` manually.

Tested manually:

- `make` installs the Python and JavaScript dependencies and runs the
  dev server
- Running `make` again just runs the def server without re-installing the
  deps.
- A change to `requirements.txt` causes `make` to reinstall the Python deps
  (read: run the `pip install` commands again)
- Also changes to `requirements-dev.txt`
- A change to `package.json` causes `make` to re-run the `npm install`

- `make test` installs the JavaScript dependencies (but not the Python
  ones, tox installs those in its venv instead), installs tox, and runs both
  the Python and the JavaScript tests.
- Python and JavaScript deps are not reinstalled when you run `make test`
  again
- `make test` does re-run `pip install -q tox` every time, though.
  This shouldn't really be necessary but I dunno if there's an easy way to
  test whether tox is already installed.
- Changes to `requirements.txt` and `requirements-dev.txt` do not cause
  `make test` to reinstall Python deps (again let tox handle it)
- Changes to `package.json` _do_ cause `make test` to re-run `npm install`

- `make coverage` always re-runs the Python tests (only, not the
  JavaScript ones, bouncer doesn't have coverage for JavaScript), even if the
  `.coverage` file already exists and is up to date.

  Always printing out an up-to-date coverage report seems like the
  behaviour that we want from running `make coverage` locally.

  I could try to make this recursively depend on all the `*.py` files
  in `bouncer/` and `tests/`, and only re-run the tests if they've
  changed, but I doubt anyone runs `make coverage` locally anyway so I
  haven't bothered.

- `make codecov` will run the Python tests in order to generate the
  `.coverage` file _if_ it doesn't already exist `make codecov` will
  _not_ re-run the Python tests if the `.coverage` file already exists,
  even if the source files have changed.

  Again, recursively depending on changes to `*.py` files would be more
  correct but not re-running the tests is the behaviour that we actually
  want from `make codecov` on Travis.

- `make clean` works, and doesn't crash if run repeatedly

- `make docker` works