### PR TITLE
raise HTTPNotFound when annotation was deleted (issue #54)

### DIFF
--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -39,6 +39,9 @@ class AnnotationController(object):
             statsd.incr("views.annotation.404.annotation_not_found")
             raise httpexceptions.HTTPNotFound(_("Annotation not found"))
 
+        if ('deleted' in document['_source'] and document['_source']['deleted']):
+            raise httpexceptions.HTTPNotFound(_("Annotation not found"))
+
         try:
             parsed_document = util.parse_document(document)
             annotation_id = parsed_document["annotation_id"]

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -37,6 +37,13 @@ class TestAnnotationController(object):
         statsd.incr.assert_called_once_with(
             "views.annotation.404.annotation_not_found")
 
+    def test_annotation_raises_http_not_found_if_annotation_deleted(self):
+        request = mock_request()
+        request.es.get.return_value['_source']['deleted'] = True
+
+        with pytest.raises(httpexceptions.HTTPNotFound):
+            views.AnnotationController(request).annotation()
+
     def test_annotation_raises_http_not_found_if_get_raises_not_found(self):
         request = mock_request()
         request.es.get.side_effect = es_exceptions.NotFoundError


### PR DESCRIPTION
1. Check for `{"deleted":True}` in the ElasticSearch response, and raise HTTPNotFound if so.

2. Add a test for this case.

Fixes https://github.com/hypothesis/bouncer/issues/54