### PR TITLE
Allow the tests to run on Python 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35
+envlist = py3
 skipsdist = True
 
 [pytest]


### PR DESCRIPTION
On for example Ubuntu 17.10 Python 3.6 is installed but Python 3.5
isn't, but the tests were configured to run on 3.5 only. This changes
them to run on any Python 3.x.