### PR TITLE
Add a minimal flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ explain = true
 
 [yapf]
 based_on_style = pep8
+
+[flake8]
+max-line-length = 160


### PR DESCRIPTION
This matches the config we have in the h repo.

This removes line-length related errors for those of us who have flake8 integrated with our editor ([ALE](https://github.com/w0rp/ale) FTW!)