### PR TITLE
Extract shared fixture from test cases

### DIFF
--- a/tests/bouncer/util_test.py
+++ b/tests/bouncer/util_test.py
@@ -53,7 +53,17 @@ def test_parse_document_returns_quote(es_annotation_doc):
     assert quote == "test_quote"
 
 
-def test_parse_document_returns_boilerplate_quote_when_no_quote(es_annotation_doc):
+@pytest.mark.parametrize('selector', [
+    # No selector (ie. a page note).
+    None,
+
+    # No quote selector. Allowed by the service even though a quote is required
+    # to anchor the annotation.
+    [{"type": "TextPositionSelector"}],
+])
+def test_parse_document_returns_boilerplate_quote_when_no_quote(es_annotation_doc, selector):
+    if selector:
+        es_annotation_doc["_source"]["target"][0]["selector"] = selector
     quote = util.parse_document(es_annotation_doc)["quote"]
     assert quote == "Hypothesis annotation for example.com"
 

--- a/tests/bouncer/util_test.py
+++ b/tests/bouncer/util_test.py
@@ -103,10 +103,11 @@ def es_annotation_doc():
     return {
         "_id": "annotation_id",
         "_source": {
-            "target": [{
-                "source": "http://example.com/example.html",
-                "selector": [{}]
-            }],
+            "target": [
+                {
+                    "source": "http://example.com/example.html",
+                }
+            ],
             "group": "__world__",
             "shared": True,
         }

--- a/tests/bouncer/util_test.py
+++ b/tests/bouncer/util_test.py
@@ -16,184 +16,96 @@ def test_parse_document_raises_if_annotated_deleted():
         })
 
 
-def test_parse_document_raises_if_no_uri():
+def test_parse_document_raises_if_no_uri(es_annotation_doc):
+    del es_annotation_doc["_source"]["target"][0]["source"]
+
     with pytest.raises(util.InvalidAnnotationError) as exc:
-        util.parse_document({
-            "_id": "annotation_id",
-            "_source": {
-                "target": [{  # no uri
-                            "selector": []
-                            }],
-                "group": "__world__",
-                "shared": True
-            }
-        })
+        util.parse_document(es_annotation_doc)
+
     assert exc.value.reason == "annotation_has_no_uri"
 
 
-def test_parse_document_raises_if_uri_not_a_string():
+def test_parse_document_raises_if_uri_not_a_string(es_annotation_doc):
+    es_annotation_doc["_source"]["target"][0]["source"] = 52
+
     with pytest.raises(util.InvalidAnnotationError) as exc:
-        util.parse_document({
-            "_id": "annotation_id",
-            "_source": {
-                "target": [{
-                            "source": 52,  # "uri" isn't a string.
-                            "selector": []
-                            }],
-                "group": "__world__",
-                "shared": True
-            }
-        })
+        util.parse_document(es_annotation_doc)
+
     assert exc.value.reason == "uri_not_a_string"
 
 
-def test_parse_document_returns_annotation_id():
-    annotation_id = util.parse_document({
-        "_id": "annotation_id",
-        "_source": {
-            "target": [{
-                "source": "http://example.com/example.html",
-                "selector": [],
-            }],
-            "group": "__world__",
-            "shared": True
-        }
-    })["annotation_id"]
-
+def test_parse_document_returns_annotation_id(es_annotation_doc):
+    annotation_id = util.parse_document(es_annotation_doc)["annotation_id"]
     assert annotation_id == "annotation_id"
 
 
-def test_parse_document_returns_document_uri():
-    document_uri = util.parse_document({
-        "_id": "annotation_id",
-        "_source": {
-            "target": [{
-                "source": "http://example.com/example.html",
-                "selector": []
-            }],
-            "group": "__world__",
-            "shared": True
-        }
-    })["document_uri"]
-
+def test_parse_document_returns_document_uri(es_annotation_doc):
+    document_uri = util.parse_document(es_annotation_doc)["document_uri"]
     assert document_uri == "http://example.com/example.html"
 
 
-def test_parse_document_returns_quote():
-    parsed_document = util.parse_document({
-        "_id": "annotation_id",
-        "_source": {
-            "target": [{
-                                "source": "http://example.com/example.html",
-                                "selector": [{
-                                    "type": "TextQuoteSelector",
-                                    "exact": "test_quote"
-                                }]
-                                }],
-            "group": "__world__",
-            "shared": True
-        }
-    })
-    quote = parsed_document["quote"]
-
+def test_parse_document_returns_quote(es_annotation_doc):
+    es_annotation_doc["_source"]["target"][0]["selector"] = [{
+        "type": "TextQuoteSelector",
+        "exact": "test_quote",
+        }]
+    quote = util.parse_document(es_annotation_doc)["quote"]
     assert quote == "test_quote"
 
 
-def test_parse_document_returns_boilerplate_quote_when_no_quote():
-    parsed_document = util.parse_document({
-        "_id": "annotation_id",
-        "_source": {
-            "target": [{
-                                "source": "http://example.com/example.html",
-                                }],
-            "group": "__world__",
-            "shared": True
-        }
-    })
-    quote = parsed_document["quote"]
-
+def test_parse_document_returns_boilerplate_quote_when_no_quote(es_annotation_doc):
+    quote = util.parse_document(es_annotation_doc)["quote"]
     assert quote == "Hypothesis annotation for example.com"
 
 
-def test_parse_document_returns_text():
-    text = util.parse_document({
-        "_id": "annotation_id",
-        "_source": {
-            "target": [{
-                "source": "http://example.com/example.html",
-                "selector": [{}]
-            }],
-            "group": "__world__",
-            "shared": True,
-            "text": "test_text"
-        }
-    })["text"]
-
+def test_parse_document_returns_text(es_annotation_doc):
+    es_annotation_doc["_source"]["text"] = "test_text"
+    text = util.parse_document(es_annotation_doc)["text"]
     assert text == "test_text"
 
 
-def test_parse_document_returns_boilerplate_when_no_text():
-    text = util.parse_document({
-        "_id": "annotation_id",
-        "_source": {
-            "target": [{
-                "source": "http://example.com/example.html",
-                "selector": [{}]
-            }],
-            "group": "__world__",
-            "shared": True,
-            "text": ""
-        }
-    })["text"]
-
+def test_parse_document_returns_boilerplate_when_no_text(es_annotation_doc):
+    text = util.parse_document(es_annotation_doc)["text"]
     assert text == util.ANNOTATION_BOILERPLATE_TEXT
 
 
-def test_parse_document_returns_show_metadata_true_when_shared_and_world():
-    show_metadata = util.parse_document({
-        "_id": "annotation_id",
-        "_source": {
-            "target": [{
-                "source": "http://example.com/example.html",
-                "selector": [{}]
-            }],
-            "group": "__world__",
-            "shared": True
-        }
-    })["show_metadata"]
-
+def test_parse_document_returns_show_metadata_true_when_shared_and_world(es_annotation_doc):
+    show_metadata = util.parse_document(es_annotation_doc)["show_metadata"]
     assert show_metadata is True
 
 
-def test_parse_document_returns_document_uri_from_web_uri_when_pdf():
-    document_uri = util.parse_document({
-        "_id": "annotation_id",
-        "_source": {
-            "target": [{
-                "source": "urn:x-pdf:the-fingerprint",
-                "selector": []
-            }],
-            "group": "__world__",
-            "shared": True,
-            "document": {"web_uri": "http://example.com/foo.pdf"}
-        }
-    })["document_uri"]
+def test_parse_document_returns_document_uri_from_web_uri_when_pdf(es_annotation_doc):
+    es_annotation_doc["_source"]["target"][0]["source"] = "urn:x-pdf:the-fingerprint"
+    es_annotation_doc["_source"]["document"] = {"web_uri": "http://example.com/foo.pdf"}
+
+    document_uri = util.parse_document(es_annotation_doc)["document_uri"]
 
     assert document_uri == "http://example.com/foo.pdf"
 
 
-def test_parse_document_raises_when_uri_from_web_uri_not_string_for_pdfs():
+def test_parse_document_raises_when_uri_from_web_uri_not_string_for_pdfs(es_annotation_doc):
+    es_annotation_doc["_source"]["target"][0]["source"] = "urn:x-pdf:the-fingerprint"
+    es_annotation_doc["_source"]["document"] = {"web_uri": 52}
+
     with pytest.raises(util.InvalidAnnotationError) as exc:
-        util.parse_document({
-            "_id": "annotation_id",
+        util.parse_document(es_annotation_doc)
+
+    assert exc.value.reason == "uri_not_a_string"
+
+
+@pytest.fixture
+def es_annotation_doc():
+    """
+    Minimal JSON document for an annotation as returned from Elasticsearch.
+
+    This contains only fields which can be assumed to exist on all annotations.
+    """
+    return {"_id": "annotation_id",
             "_source": {
                 "target": [{
-                            "source": "urn:x-pdf:the-fingerprint",
-                            "selector": []
-                            }],
+                    "source": "http://example.com/example.html",
+                    "selector": [{}]
+                }],
                 "group": "__world__",
                 "shared": True,
-                "document": {"web_uri": 52}
-            }
-        })
-    assert exc.value.reason == "uri_not_a_string"
+            }}

--- a/tests/bouncer/util_test.py
+++ b/tests/bouncer/util_test.py
@@ -100,12 +100,14 @@ def es_annotation_doc():
 
     This contains only fields which can be assumed to exist on all annotations.
     """
-    return {"_id": "annotation_id",
-            "_source": {
-                "target": [{
-                    "source": "http://example.com/example.html",
-                    "selector": [{}]
-                }],
-                "group": "__world__",
-                "shared": True,
-            }}
+    return {
+        "_id": "annotation_id",
+        "_source": {
+            "target": [{
+                "source": "http://example.com/example.html",
+                "selector": [{}]
+            }],
+            "group": "__world__",
+            "shared": True,
+        }
+    }


### PR DESCRIPTION
Many tests in `util_test.py` duplicated the same fixture data for fields
that are expected to be present in every ES annotation JSON document.

Extracting the fixture will make it easier to add new fields to it.