### PR TITLE
Redirect user to original URL instead of proxy if annotation was created by a third-party user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,11 @@ ELASTICSEARCH_AWS_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,REGION}
   request signing with the given credentials. This allows making requests to an
   AWS Elasticsearch domain as an IAM user.
 
+HYPOTHESIS_AUTHORITY
+  The domain name of the Hypothesis service's first party authority.
+  This is usually the same as the domain name of the Hypothesis service
+  (default: localhost).
+
 HYPOTHESIS_URL
   The URL of the Hypothesis front page that requests to bouncer's front page
   will be redirected to (default: https://hypothes.is)

--- a/bouncer/app.py
+++ b/bouncer/app.py
@@ -27,6 +27,8 @@ def settings():
         "debug": debug,
         "elasticsearch_index": os.environ.get("ELASTICSEARCH_INDEX",
                                               "hypothesis"),
+        "hypothesis_authority": os.environ.get("HYPOTHESIS_AUTHORITY",
+                                               "localhost"),
         "hypothesis_url": os.environ.get("HYPOTHESIS_URL",
                                          "https://hypothes.is"),
         "via_base_url": via_base_url,

--- a/bouncer/scripts/redirect.js
+++ b/bouncer/scripts/redirect.js
@@ -31,20 +31,20 @@ function defaultNavigateTo(url) {
   window.location.replace(url);
 }
 
-/** Navigate the browser to the requested annotation.
+/**
+ * Navigate the browser to the requested annotation.
  *
  * If the browser is Chrome and our Chrome extension is installed then
  * navigate to the annotation's direct link for the Chrome extension.
  * If the Chrome extension isn't installed or the browser isn't Chrome then
  * navigate to the annotation's Via direct link.
  *
+ * @param {(url: string) => void} [navigateTo]
+ * @param {Settings} [settings]
  */
-function redirect(navigateToFn) {
-  // Use the test navigateTo() function if one was passed in, the real
-  // navigateTo() otherwise.
-  var navigateTo = navigateToFn || defaultNavigateTo;
-
-  var settings = getSettings(document);
+function redirect(navigateTo, settings) {
+  navigateTo = navigateTo || defaultNavigateTo; // Test seam
+  settings = settings || getSettings(document); // Test seam
 
   var chrome = window.chrome;
   if (chrome && chrome.runtime && chrome.runtime.sendMessage) {

--- a/bouncer/scripts/redirect.js
+++ b/bouncer/scripts/redirect.js
@@ -13,7 +13,8 @@
  * @prop {string} extensionUrl - Original URL of the page plus a fragment that
  *   triggers the extension to activate when the user visits the page. This is
  *   also used in cases where the original URL embeds the client.
- * @prop {string} viaUrl - Proxy URL.
+ * @prop {string|null} viaUrl - Proxy URL of `null` if the proxy cannot be used
+ *   to display this annotation in context.
  */
 
 /**
@@ -45,6 +46,13 @@ function defaultNavigateTo(url) {
 function redirect(navigateTo, settings) {
   navigateTo = navigateTo || defaultNavigateTo; // Test seam
   settings = settings || getSettings(document); // Test seam
+
+  // If the proxy cannot be used with this URL, send the user directly to the
+  // original page.
+  if (!settings.viaUrl) {
+    navigateTo(settings.extensionUrl);
+    return;
+  }
 
   var chrome = window.chrome;
   if (chrome && chrome.runtime && chrome.runtime.sendMessage) {

--- a/bouncer/scripts/redirect.js
+++ b/bouncer/scripts/redirect.js
@@ -1,6 +1,26 @@
 'use strict';
 
-/** Return the settings object that the server injected into the page. */
+/**
+ * Configuration information for the client-side code that detects the best way
+ * to route the user to a URL with Hypothesis activated and specified
+ * annotations selected.
+ *
+ * This is rendered into Bouncer's interstitial page by the backend service.
+ *
+ * @typedef {Object} Settings
+ * @prop {string} chromeExtensionId - ID of the Chrome extension that Bouncer
+ *   should check for in the user's browser.
+ * @prop {string} extensionUrl - Original URL of the page plus a fragment that
+ *   triggers the extension to activate when the user visits the page. This is
+ *   also used in cases where the original URL embeds the client.
+ * @prop {string} viaUrl - Proxy URL.
+ */
+
+/**
+ * Return the settings object that the server injected into the page.
+ *
+ * @return {Settings}
+ */
 function getSettings(document) {
   return JSON.parse(
     document.querySelector('script.js-bouncer-settings').textContent);

--- a/bouncer/scripts/test/redirect-test.js
+++ b/bouncer/scripts/test/redirect-test.js
@@ -161,4 +161,14 @@ describe('#redirect', function () {
       navigateTo.calledWithExactly('http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q'),
       true);
   });
+
+  it('redirects to original URL if no Via URL provided', function () {
+    settings.viaUrl = null;
+    var navigateTo = sinon.stub();
+
+    redirect(navigateTo, settings);
+
+    assert.isTrue(navigateTo.calledOnce);
+    assert.isTrue(navigateTo.calledWithExactly(settings.extensionUrl));
+  });
 });

--- a/bouncer/scripts/test/redirect-test.js
+++ b/bouncer/scripts/test/redirect-test.js
@@ -2,17 +2,14 @@
 
 var redirect = require('../redirect.js');
 
-describe('redirect()', function () {
+describe('#redirect', function () {
+  var settings;
   beforeEach(function () {
     window.chrome = undefined;
-    window.document.querySelector = function () {
-      return {
-        textContent: JSON.stringify({
-          chromeExtensionId: 'test-extension-id',
-          extensionUrl: 'http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q',
-          viaUrl: 'https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q',
-        }),
-      };
+    settings = {
+      chromeExtensionId: 'test-extension-id',
+      extensionUrl: 'http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q',
+      viaUrl: 'https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q',
     };
     sinon.stub(window.console, 'error');
   });
@@ -21,11 +18,29 @@ describe('redirect()', function () {
     window.console.error.restore();
   });
 
+  it('reads settings from the page by default', function () {
+    var settings = {
+      chromeExtensionId: 'a-b-c',
+      extensionUrl: 'https://example.org/#annotations:123',
+      viaUrl: 'https://proxy.it/#annotations:123',
+    };
+    var settingsEl = document.createElement('script');
+    settingsEl.type = 'application/json';
+    settingsEl.className = 'js-bouncer-settings';
+    settingsEl.textContent = JSON.stringify(settings);
+    document.body.appendChild(settingsEl);
+    var navigateTo = sinon.stub();
+
+    redirect(navigateTo);
+
+    assert.isTrue(navigateTo.calledWith(settings.viaUrl));
+  });
+
   it('redirects to Via if not Chrome', function () {
     window.chrome = undefined;  // The user isn't using Chrome.
     var navigateTo = sinon.stub();
 
-    redirect(navigateTo);
+    redirect(navigateTo, settings);
 
     assert.equal(navigateTo.calledOnce, true);
     assert.equal(
@@ -38,7 +53,7 @@ describe('redirect()', function () {
     window.chrome = {};
     var navigateTo = sinon.stub();
 
-    redirect(navigateTo);
+    redirect(navigateTo, settings);
 
     assert.equal(navigateTo.calledOnce, true);
     assert.equal(
@@ -51,7 +66,7 @@ describe('redirect()', function () {
     window.chrome = {runtime: {}};
     var navigateTo = sinon.stub();
 
-    redirect(navigateTo);
+    redirect(navigateTo, settings);
 
     assert.equal(navigateTo.calledOnce, true);
     assert.equal(
@@ -69,7 +84,7 @@ describe('redirect()', function () {
     };
     var navigateTo = sinon.stub();
 
-    redirect(navigateTo);
+    redirect(navigateTo, settings);
 
     assert.equal(navigateTo.calledOnce, true);
     assert.equal(
@@ -88,7 +103,7 @@ describe('redirect()', function () {
     };
     var navigateTo = sinon.stub();
 
-    redirect(navigateTo);
+    redirect(navigateTo, settings);
 
     assert.equal(navigateTo.calledOnce, true);
     assert.equal(
@@ -106,7 +121,7 @@ describe('redirect()', function () {
       },
     };
 
-    redirect(sinon.stub());
+    redirect(sinon.stub(), settings);
 
     assert.equal(console.error.called, true);
   });
@@ -118,7 +133,7 @@ describe('redirect()', function () {
       },
     };
 
-    redirect(function () {});
+    redirect(function () {}, settings);
 
     assert.equal(window.chrome.runtime.sendMessage.calledOnce, true);
     assert.equal(window.chrome.runtime.sendMessage.firstCall.args[0],
@@ -139,7 +154,7 @@ describe('redirect()', function () {
     };
     var navigateTo = sinon.stub();
 
-    redirect(navigateTo);
+    redirect(navigateTo, settings);
 
     assert.equal(navigateTo.calledOnce, true);
     assert.equal(

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -76,6 +76,8 @@ def parse_document(document):
     if document['_source'].get('deleted', False) is True:
         raise DeletedAnnotationError()
 
+    authority = annotation["authority"]
+
     # If an annotation isn't deleted then we assume that it always has "group"
     # and "shared".
     group = annotation["group"]
@@ -127,6 +129,7 @@ def parse_document(document):
             "uri_not_a_string")
 
     return {
+            "authority": authority,
             "annotation_id": annotation_id,
             "document_uri": document_uri,
             "show_metadata": show_metadata,

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -66,7 +66,7 @@ def parse_document(document):
     :param document: the Elasticsearch annotation document to parse
     :type document: dict
 
-    :rtype: 2-tuple of annotation ID (string) and document URI (string)
+    :returns: A dict with extracted metadata properties
 
     """
     # We assume that Elasticsearch documents always have "_id" and "_source".

--- a/tests/bouncer/util_test.py
+++ b/tests/bouncer/util_test.py
@@ -103,6 +103,11 @@ def test_parse_document_raises_when_uri_from_web_uri_not_string_for_pdfs(es_anno
     assert exc.value.reason == "uri_not_a_string"
 
 
+def test_parse_document_returns_authority(es_annotation_doc):
+    authority = util.parse_document(es_annotation_doc)["authority"]
+    assert authority == "hypothes.is"
+
+
 @pytest.fixture
 def es_annotation_doc():
     """
@@ -113,6 +118,7 @@ def es_annotation_doc():
     return {
         "_id": "annotation_id",
         "_source": {
+            "authority": "hypothes.is",
             "target": [
                 {
                     "source": "http://example.com/example.html",

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -162,6 +162,15 @@ class TestAnnotationController(object):
         assert data["viaUrl"] == (
                 "https://via.hypothes.is/http://example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
 
+    def test_annotation_omits_via_url_for_third_party_annotations(self, parse_document):
+        parse_document.return_value["authority"] = "partner.org"
+        template_data = (
+            views.AnnotationController(mock_request()).annotation())
+
+        data = json.loads(template_data["data"])
+
+        assert data["viaUrl"] is None
+
 
 @pytest.mark.usefixtures("statsd")
 def test_index_increments_stat(statsd):
@@ -332,6 +341,7 @@ def parse_document(request):
     request.addfinalizer(patcher.stop)
     parse_document.return_value = {
         "annotation_id": "AVLlVTs1f9G3pW-EYc6q",
+        "authority": "localhost",
         "document_uri": "http://www.example.com/example.html",
         "show_metadata": True,
         "quote": "Hypothesis annotation for www.example.com",
@@ -355,6 +365,7 @@ def mock_request():
                                  "elasticsearch_host": "http://localhost/",
                                  "elasticsearch_port": "9200",
                                  "elasticsearch_index": "hypothesis",
+                                 "hypothesis_authority": "localhost",
                                  "hypothesis_url": "https://hypothes.is",
                                  "via_base_url": "https://via.hypothes.is"}
     request.matchdict = {"id": "AVLlVTs1f9G3pW-EYc6q"}

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -107,31 +107,23 @@ class TestAnnotationController(object):
             "views.annotation.200.annotation_found")
 
     def test_annotation_returns_chrome_extension_id(self):
-        template_data = (
-            views.AnnotationController(mock_request()).annotation())
-
+        template_data = views.AnnotationController(mock_request()).annotation()
         data = json.loads(template_data["data"])
         assert data["chromeExtensionId"] == "test-extension-id"
 
     def test_annotation_returns_quote(self):
-        template_data = (
-            views.AnnotationController(mock_request()).annotation())
-
+        template_data = views.AnnotationController(mock_request()).annotation()
         quote = template_data["quote"]
         assert quote == "Hypothesis annotation for www.example.com"
 
     def test_annotation_returns_via_url(self):
-        template_data = (
-            views.AnnotationController(mock_request()).annotation())
-
+        template_data = views.AnnotationController(mock_request()).annotation()
         data = json.loads(template_data["data"])
         assert data["viaUrl"] == (
                 "https://via.hypothes.is/http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
 
     def test_annotation_returns_extension_url(self):
-        template_data = (
-            views.AnnotationController(mock_request()).annotation())
-
+        template_data = views.AnnotationController(mock_request()).annotation()
         data = json.loads(template_data["data"])
         assert data["extensionUrl"] == (
                 "http://www.example.com/example.html#annotations:AVLlVTs1f9G3pW-EYc6q")
@@ -139,8 +131,7 @@ class TestAnnotationController(object):
     def test_annotation_strips_fragment_identifiers(self, parse_document):
         parse_document.return_value["document_uri"] = (
             "http://example.com/example.html#foobar")
-        template_data = (
-            views.AnnotationController(mock_request()).annotation())
+        template_data = views.AnnotationController(mock_request()).annotation()
 
         data = json.loads(template_data["data"])
 
@@ -152,8 +143,7 @@ class TestAnnotationController(object):
     def test_annotation_strips_bare_fragment_identifiers(self, parse_document):
         parse_document.return_value["document_uri"] = (
            "http://example.com/example.html#")
-        template_data = (
-            views.AnnotationController(mock_request()).annotation())
+        template_data = views.AnnotationController(mock_request()).annotation()
 
         data = json.loads(template_data["data"])
 
@@ -164,8 +154,7 @@ class TestAnnotationController(object):
 
     def test_annotation_omits_via_url_for_third_party_annotations(self, parse_document):
         parse_document.return_value["authority"] = "partner.org"
-        template_data = (
-            views.AnnotationController(mock_request()).annotation())
+        template_data = views.AnnotationController(mock_request()).annotation()
 
         data = json.loads(template_data["data"])
 


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/bouncer/pull/60, will need rebasing.**

If a direct-linked annotation was made on a page that embeds Hypothesis and uses third party accounts then the page is highly likely to be broken if delivered through the Via proxy service since Via does not allow cookies to be read/written amongst other issues. Since we know the page already embeds Hypothesis we can just redirect the user to the original URL in this case.

Whether or not an annotation is "third party" is determined by comparing the "authority" field of the Elasticsearch document with a `HYPOTHESIS_AUTHORITY` setting configured in Bouncer's environment.

**Testing steps**

1. Run the client, h and publisher-account-test-site services with the following env vars configured:
   ```
   HYPOTHESIS_AUTHORITY=localhost
   BOUNCER_URL=http://127.0.0.1:8000
   ```
2. Visit the publisher account test site's demo page and copy a direct link from the "Share" icon in the client
3. Visit that direct link in a browser that would normally use Via. The local bouncer service should redirect to the original URL instead.
4. Repeat steps (2) and (3) with a normal Hypothesis annotation in the same browser and Bouncer should attempt to redirect to Via.