### PR TITLE
Remove deprecated and redundant pip `--use-wheel` argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCKER_TAG = dev
 deps:
 	pip install --upgrade pip
 	pip install --upgrade wheel
-	pip install --use-wheel -r requirements-dev.txt
+	pip install -r requirements-dev.txt
 	npm install
 
 dev:


### PR DESCRIPTION
As noted at https://pip.pypa.io/en/stable/user_guide/, pip automatically
installs wheels when they are available, so `--use-wheel` is a no-op
which existed because of the counterpart `--no-use-wheel`. That was in
turn removed in favor of `--no-binary` in pip 10.0.