### PR TITLE
Connect to elasticsearch 6.2.0 cluster

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,17 +27,13 @@ DEBUG
   variable set in the environment then unexpected Python exceptions will be
   reported to Sentry and a generic error page shown to the user.
 
-ELASTICSEARCH_HOST
-  The hostname of the Elasticsearch server that bouncer will read annotations
-  from (default: localhost)
+ELASTICSEARCH_URL
+  The url (host and port) of the Elasticsearch server that bouncer will read 
+  annotations from (default: localhost:9201)
 
 ELASTICSEARCH_INDEX
   The name of the Elasticsearch index that bouncer will read annotations
   from (default: hypothesis)
-
-ELASTICSEARCH_PORT
-  The port of the Elasticsearch server that bouncer will read annotations
-  from (default: 9200)
 
 ELASTICSEARCH_AWS_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,REGION}
   If all three of these environment variables are set, bouncer will assume that

--- a/README.rst
+++ b/README.rst
@@ -29,17 +29,11 @@ DEBUG
 
 ELASTICSEARCH_URL
   The url (host and port) of the Elasticsearch server that bouncer will read 
-  annotations from (default: localhost:9201)
+  annotations from (default: http://localhost:9201)
 
 ELASTICSEARCH_INDEX
   The name of the Elasticsearch index that bouncer will read annotations
   from (default: hypothesis)
-
-ELASTICSEARCH_AWS_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,REGION}
-  If all three of these environment variables are set, bouncer will assume that
-  it must connect to Elasticsearch over HTTPS and will enable AWS Auth v4
-  request signing with the given credentials. This allows making requests to an
-  AWS Elasticsearch domain as an IAM user.
 
 HYPOTHESIS_AUTHORITY
   The domain name of the Hypothesis service's first party authority.

--- a/bouncer/app.py
+++ b/bouncer/app.py
@@ -36,13 +36,6 @@ def settings():
 
     if 'ELASTICSEARCH_URL' in os.environ:
         result['elasticsearch_url'] = os.environ['ELASTICSEARCH_URL']
-    if 'ELASTICSEARCH_AWS_ACCESS_KEY_ID' in os.environ:
-        result['elasticsearch_aws_access_key_id'] = os.environ['ELASTICSEARCH_AWS_ACCESS_KEY_ID']
-    if 'ELASTICSEARCH_AWS_SECRET_ACCESS_KEY' in os.environ:
-        result['elasticsearch_aws_secret_access_key'] = os.environ['ELASTICSEARCH_AWS_SECRET_ACCESS_KEY']
-    if 'ELASTICSEARCH_AWS_REGION' in os.environ:
-        result['elasticsearch_aws_region'] = os.environ['ELASTICSEARCH_AWS_REGION']
-
     return result
 
 

--- a/bouncer/app.py
+++ b/bouncer/app.py
@@ -34,10 +34,8 @@ def settings():
         "via_base_url": via_base_url,
     }
 
-    if 'ELASTICSEARCH_HOST' in os.environ:
-        result['elasticsearch_host'] = os.environ['ELASTICSEARCH_HOST']
-    if 'ELASTICSEARCH_PORT' in os.environ:
-        result['elasticsearch_port'] = int(os.environ['ELASTICSEARCH_PORT'])
+    if 'ELASTICSEARCH_URL' in os.environ:
+        result['elasticsearch_url'] = os.environ['ELASTICSEARCH_URL']
     if 'ELASTICSEARCH_AWS_ACCESS_KEY_ID' in os.environ:
         result['elasticsearch_aws_access_key_id'] = os.environ['ELASTICSEARCH_AWS_ACCESS_KEY_ID']
     if 'ELASTICSEARCH_AWS_SECRET_ACCESS_KEY' in os.environ:

--- a/bouncer/search.py
+++ b/bouncer/search.py
@@ -1,36 +1,19 @@
-import certifi
-from elasticsearch import Elasticsearch, RequestsHttpConnection
-from requests_aws4auth import AWS4Auth
+from elasticsearch import Elasticsearch
 
 
 def get_client(settings):
     """Return a client for the Elasticsearch index."""
-    host = {'host': settings['elasticsearch_host'],
-            'port': settings['elasticsearch_port']}
+    host = settings['elasticsearch_url']
     kwargs = {}
 
-    have_aws_creds = ('elasticsearch_aws_access_key_id' in settings and
-                      'elasticsearch_aws_secret_access_key' in settings and
-                      'elasticsearch_aws_region' in settings)
-    if have_aws_creds:
-        auth = AWS4Auth(settings['elasticsearch_aws_access_key_id'],
-                        settings['elasticsearch_aws_secret_access_key'],
-                        settings['elasticsearch_aws_region'],
-                        'es')
-
-        kwargs['http_auth'] = auth
-        kwargs['use_ssl'] = True
-        kwargs['verify_certs'] = True
-        kwargs['ca_certs'] = certifi.where()
-        kwargs['connection_class'] = RequestsHttpConnection
-
+    # nb. No AWS credentials here because we assume that if using AWS-managed
+    # ES, the cluster lives inside a VPC.
     return Elasticsearch([host], **kwargs)
 
 
 def includeme(config):
     settings = config.registry.settings
-    settings.setdefault('elasticsearch_host', 'localhost')
-    settings.setdefault('elasticsearch_port', 9200)
+    settings.setdefault('elasticsearch_url', 'http://localhost:9201')
 
     config.registry['es.client'] = get_client(settings)
     config.add_request_method(lambda r: r.registry['es.client'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2018.4.16
-elasticsearch>=2.0.0,<7.0.0
+elasticsearch==6.2.0
 gunicorn==19.9.0
 pyramid==1.9.2
 pyramid-jinja2==2.7

--- a/tests/bouncer/search_test.py
+++ b/tests/bouncer/search_test.py
@@ -4,58 +4,29 @@ from mock import (
     patch,
 )
 
-import certifi
-from elasticsearch import Elasticsearch, RequestsHttpConnection
+from elasticsearch import Elasticsearch
 
 from bouncer.search import get_client, includeme
 
 
 class TestGetClient(object):
     def test_returns_client(self):
-        client = get_client({'elasticsearch_host': 'foo',
-                             'elasticsearch_port': 9200})
+        client = get_client({'elasticsearch_url': 'foo:9200'})
 
         assert isinstance(client, Elasticsearch)
 
     @patch('bouncer.search.Elasticsearch')
     def test_configures_client(self, es_mock):
-        get_client({'elasticsearch_host': 'foo',
-                    'elasticsearch_port': 9200})
+        get_client({'elasticsearch_url': 'foo:9200'})
 
-        es_mock.assert_called_once_with([{'host': 'foo', 'port': 9200}])
-
-    @patch('bouncer.search.AWS4Auth')
-    @patch('bouncer.search.Elasticsearch')
-    def test_configures_aws_auth(self, es_mock, awsauth_mock):
-        get_client({'elasticsearch_host': 'foo',
-                    'elasticsearch_port': 9200,
-                    'elasticsearch_aws_access_key_id': 'foo',
-                    'elasticsearch_aws_secret_access_key': 'bar',
-                    'elasticsearch_aws_region': 'spain'})
-
-        awsauth_mock.assert_called_once_with('foo', 'bar', 'spain', 'es')
-
-    @patch('bouncer.search.AWS4Auth')
-    @patch('bouncer.search.Elasticsearch')
-    def test_configures_es_for_aws_auth(self, es_mock, awsauth_mock):
-        auth_result = awsauth_mock.return_value
-        get_client({'elasticsearch_host': 'foo',
-                    'elasticsearch_port': 9200,
-                    'elasticsearch_aws_access_key_id': 'foo',
-                    'elasticsearch_aws_secret_access_key': 'bar',
-                    'elasticsearch_aws_region': 'spain'})
-
-        es_mock.assert_called_once_with([{'host': 'foo', 'port': 9200}],
-                                        http_auth=auth_result,
-                                        use_ssl=True,
-                                        verify_certs=True,
-                                        ca_certs=certifi.where(),
-                                        connection_class=(
-                                            RequestsHttpConnection))
+        es_mock.assert_called_once_with(['foo:9200'])
 
 
 def test_includeme():
     configurator = MagicMock()
+    configurator.registry.settings = {
+        'elasticsearch_url': 'foo:9200',
+    }
 
     includeme(configurator)
 

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -351,8 +351,7 @@ def mock_request():
     request = testing.DummyRequest()
     request.registry.settings = {"chrome_extension_id": "test-extension-id",
                                  "debug": False,
-                                 "elasticsearch_host": "http://localhost/",
-                                 "elasticsearch_port": "9200",
+                                 "elasticsearch_url": "http://localhost:9201",
                                  "elasticsearch_index": "hypothesis",
                                  "hypothesis_authority": "localhost",
                                  "hypothesis_url": "https://hypothes.is",


### PR DESCRIPTION
Upgrading elasticsearch from 1.5.0 to 6.2.0.

- [ ] Install 6.2.0 elasticsearch python package.
- [ ] Connect to the 6.2.0 elasticsearch cluster.
