### PR TITLE
Update the default Elasticsearch port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ DEBUG
 
 ELASTICSEARCH_URL
   The url (host and port) of the Elasticsearch server that bouncer will read 
-  annotations from (default: http://localhost:9201)
+  annotations from (default: http://localhost:9200)
 
 ELASTICSEARCH_INDEX
   The name of the Elasticsearch index that bouncer will read annotations

--- a/bouncer/search.py
+++ b/bouncer/search.py
@@ -13,7 +13,7 @@ def get_client(settings):
 
 def includeme(config):
     settings = config.registry.settings
-    settings.setdefault('elasticsearch_url', 'http://localhost:9201')
+    settings.setdefault('elasticsearch_url', 'http://localhost:9200')
 
     config.registry['es.client'] = get_client(settings)
     config.add_request_method(lambda r: r.registry['es.client'],

--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -351,7 +351,7 @@ def mock_request():
     request = testing.DummyRequest()
     request.registry.settings = {"chrome_extension_id": "test-extension-id",
                                  "debug": False,
-                                 "elasticsearch_url": "http://localhost:9201",
+                                 "elasticsearch_url": "http://localhost:9200",
                                  "elasticsearch_index": "hypothesis",
                                  "hypothesis_authority": "localhost",
                                  "hypothesis_url": "https://hypothes.is",


### PR DESCRIPTION
Update the default ES port following the merge of https://github.com/hypothesis/h/pull/5215

CC @hmstepanek 