### PR TITLE
Add npm and pip caching to speed up Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ python:
   - "3.5"
 env:
   - NODE_VERSION="6.9"
+cache:
+  directories:
+    - node_modules
+    - $HOME/.cache/pip
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log
 before_install:
   - nvm install $NODE_VERSION
   - pip install codecov


### PR DESCRIPTION
Copy over the Travis caching configuration from the h repo to speed up
future Travis CI builds.