### PR TITLE
Avoid redirecting user to Via if target URL is known to embed client

### DIFF
--- a/bouncer/embed_detector.py
+++ b/bouncer/embed_detector.py
@@ -1,28 +1,27 @@
+import fnmatch
 import re
 from urllib.parse import urlparse
 
-"""
-Hardcoded URL patterns where client is assumed to be embedded.
-
-Only the hostname and path are included in the pattern. The path must be
-specified.
-
-These are regular expressions so periods must be escaped.
-"""
+# Hardcoded URL patterns where client is assumed to be embedded.
+#
+# Only the hostname and path are included in the pattern. The path must be
+# specified; use "example.com/*" to match all URLs on a particular domain.
+#
+# Patterns are shell-style wildcards ('*' matches any number of chars, '?'
+# matches a single char).
 PATTERNS = [
-    "h\.readthedocs\.io/.*",
-    "web\.hypothes\.is/blog/.*",
+    "h.readthedocs.io/*",
+    "web.hypothes.is/blog/*",
 ]
 
-COMPILED_PATTERNS = [re.compile(pat) for pat in PATTERNS]
+COMPILED_PATTERNS = [re.compile(fnmatch.translate(pat)) for pat in PATTERNS]
 
 
 def url_embeds_client(url):
     """
     Test whether ``url`` is known to embed the client.
 
-    This currently just tests the URL against the hardcoded regex list
-    ``PATTERNS``.
+    This currently just tests the URL against the pattern list ``PATTERNS``.
 
     Only the hostname and path of the URL are tested. Returns false for non-HTTP
     URLs.

--- a/bouncer/embed_detector.py
+++ b/bouncer/embed_detector.py
@@ -1,0 +1,44 @@
+import re
+from urllib.parse import urlparse
+
+"""
+Hardcoded URL patterns where client is assumed to be embedded.
+
+Only the hostname and path are included in the pattern. The path must be
+specified.
+
+These are regular expressions so periods must be escaped.
+"""
+PATTERNS = [
+    "h\.readthedocs\.io/.*",
+    "web\.hypothes\.is/blog/.*",
+]
+
+COMPILED_PATTERNS = [re.compile(pat) for pat in PATTERNS]
+
+
+def url_embeds_client(url):
+    """
+    Test whether ``url`` is known to embed the client.
+
+    This currently just tests the URL against the hardcoded regex list
+    ``PATTERNS``.
+
+    Only the hostname and path of the URL are tested. Returns false for non-HTTP
+    URLs.
+
+    :return: True if the URL matches a pattern.
+    """
+    parsed_url = urlparse(url)
+    if not parsed_url.scheme.startswith("http"):
+        return False
+
+    path = parsed_url.path
+    if not path:
+        path = "/"
+    netloc_and_path = parsed_url.netloc + path
+
+    for pat in COMPILED_PATTERNS:
+        if pat.fullmatch(netloc_and_path):
+            return True
+    return False

--- a/tests/bouncer/embed_detector_test.py
+++ b/tests/bouncer/embed_detector_test.py
@@ -1,0 +1,36 @@
+import pytest
+
+from bouncer.embed_detector import url_embeds_client
+
+
+class TestUrlEmbedsClient:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Matching HTTPS URL.
+            "https://web.hypothes.is/blog/article.foo",
+            # Matching HTTP URL.
+            "http://web.hypothes.is/blog/article.foo",
+            # Path omitted.
+            "http://h.readthedocs.io",
+            # Matching URLs with ignored query string / fragment.
+            "http://web.hypothes.is/blog/article.foo?ignore_me=1",
+            "http://web.hypothes.is/blog/article.foo#ignoreme",
+        ],
+    )
+    def test_returns_true_for_matching_url(self, url):
+        assert url_embeds_client(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # Non-matching domain.
+            "http://example.com",
+            # Non-matching path.
+            "http://web.hypothes.is/help/article.foo",
+            # Only HTTP* URLs can match.
+            "nothttp://test-domain.com/fulltext",
+        ],
+    )
+    def test_returns_false_for_non_matching_url(self, url):
+        assert url_embeds_client(url) is False


### PR DESCRIPTION
If the target URL is known to embed the client, sending the user
directly to that URL will be a better experience than sending the user
through a proxy service.

There are various ways that we could detect whether a target URL embeds
the client. This commit implements the dumbest possible approach of a
hardcoded list of URL patterns.

The initial list includes a couple of Hypothesis-related URLs. Our first use for this will be in solving https://github.com/hypothesis/product-backlog/issues/814. We'll add the URL pattern(s) for that once they have been confirmed.