### PR TITLE
Add APA URL prefixes to embed list

### DIFF
--- a/bouncer/embed_detector.py
+++ b/bouncer/embed_detector.py
@@ -10,8 +10,15 @@ from urllib.parse import urlparse
 # Patterns are shell-style wildcards ('*' matches any number of chars, '?'
 # matches a single char).
 PATTERNS = [
+    # Hypothesis websites.
     "h.readthedocs.io/*",
     "web.hypothes.is/blog/*",
+
+    # Publisher partners:
+
+    # American Psychological Organization.
+    "psycnet.apa.org/fulltext/*",
+    "awspntest.apa.org/fulltext/*",
 ]
 
 COMPILED_PATTERNS = [re.compile(fnmatch.translate(pat)) for pat in PATTERNS]


### PR DESCRIPTION
**Depends on https://github.com/hypothesis/bouncer/pull/155**

Add the URL prefixes supplied by APA to the list of URL patterns assumed to embed the Hypothesis client and therefore not require Via.

Fixes https://github.com/hypothesis/product-backlog/issues/814