### PR TITLE
Refactor tox.ini and Makefile

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+branch = True
+parallel = True
+source =
+    bouncer
+    tests/bouncer
+
+[report]
+show_missing = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,11 @@ before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 before_install:
   - nvm install $NODE_VERSION
-install:
-  - make deps
+install: pip install tox tox-pip-extensions
 jobs:
   include:
     - name: "Test"
-      before_install:
-        - pip install codecov
       script: make test
-      after_success:
-        - codecov
+      after_success: make coverage codecov
     - name: "Lint"
       script: make lint

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,8 @@ node {
 
     stage('test') {
         testApp(image: img, runArgs: '-u root') {
-            sh 'pip install -q tox'
-            sh 'cd /var/lib/bouncer && tox'
+            sh 'pip install -q tox tox-pip-extensions'
+            sh 'cd /var/lib/bouncer && tox -e py36-tests'
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
     stage('test') {
         testApp(image: img, runArgs: '-u root') {
             sh 'pip install -q tox tox-pip-extensions'
-            sh 'cd /var/lib/bouncer && tox -e py36-tests'
+            sh 'cd /var/lib/bouncer && tox -e py35-tests'
         }
     }
 

--- a/Makefile
+++ b/Makefile
@@ -17,33 +17,33 @@ help:
 
 .PHONY: dev
 dev: node_modules/.uptodate
-	tox -e py36-dev
+	tox -e py35-dev
 
 .PHONY: lint
 lint:
-	tox -e py36-lint
+	tox -e py35-lint
 	./node_modules/.bin/eslint bouncer/scripts
 
 .PHONY: test
 test: node_modules/.uptodate
-	tox -e py36-tests
+	tox -e py35-tests
 	./node_modules/karma/bin/karma start karma.config.js
 
 .PHONY: coverage
 coverage:
-	tox -e py36-coverage
+	tox -e py35-coverage
 
 .PHONY: codecov
 codecov:
-	tox -e py36-codecov
+	tox -e py35-codecov
 
 .PHONY: docstrings
 docstrings:
-	tox -e py36-docstrings
+	tox -e py35-docstrings
 
 .PHONY: checkdocstrings
 checkdocstrings:
-	tox -e py36-checkdocstrings
+	tox -e py35-checkdocstrings
 
 .PHONY: docker
 docker:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ checkdocstrings:
 
 .PHONY: docker
 docker:
-	git archive --format=tar.gz HEAD | docker build -t hypothesis/hypothesis:$(DOCKER_TAG) -
+	git archive --format=tar.gz HEAD | docker build -t hypothesis/bouncer:$(DOCKER_TAG) -
 
 .PHONY: clean
 clean:

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -144,7 +144,7 @@ def get_pretty_url(url):
     """
     try:
         parsed_url = parse.urlparse(url)
-    except (AttributeError, ValueError) as e:
+    except (AttributeError, ValueError):
         return None
 
     pretty_url = parsed_url.netloc[:NETLOC_MAX_LENGTH]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,0 @@
--r requirements.txt
-
-coverage
-mock
-prospector
-pytest
-pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36-tests
+envlist = py35-tests
 skipsdist = true
 requires = tox-pip-extensions
 tox_pip_extensions_ext_venv_update = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,39 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
-envlist = py3
-skipsdist = True
-
-[pytest]
-testpaths = tests
+envlist = py36-tests
+skipsdist = true
+requires = tox-pip-extensions
+tox_pip_extensions_ext_venv_update = true
 
 [testenv]
+skip_install = true
+passenv =
+    dev: CHROME_EXTENSION_ID
+    dev: DEBUG
+    dev: HYPOTHESIS_AUTHORITY
+    dev: HYPOTHESIS_URL
+    dev: SENTRY_DSN
 deps =
-    coverage
-    mock
-    pytest
-    -r{toxinidir}/requirements.txt
-commands = coverage run --source bouncer,tests/bouncer -m pytest -Werror {posargs:tests/bouncer/}
+    tests: coverage
+    {tests,docstrings,checkdocstrings}: pytest
+    {tests,docstrings,checkdocstrings}: factory-boy
+    {tests,docstrings,checkdocstrings}: mock
+    lint: flake8
+    coverage: coverage
+    codecov: codecov
+    docstrings: sphinx-autobuild
+    {docstrings,checkdocstrings}: sphinx
+    dev: ipython
+    dev: ipdb
+    -r requirements.txt
+whitelist_externals =
+    dev: gunicorn
+commands =
+    dev: {posargs:gunicorn --reload "bouncer.app:app()"}
+    lint: flake8 .
+    tests: coverage run -m pytest -Werror {posargs:tests/bouncer/}
+    {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envtmpdir}/rst .
+    docstrings: sphinx-autobuild -BqT -z bouncer -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
+    checkdocstrings: sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
+    coverage: -coverage combine
+    coverage: coverage report
+    codecov: codecov


### PR DESCRIPTION
Refactor `Makefile` and `tox.ini` to be the same as the ones used in h and soon to be used in all our apps.

Also add a `.coveragerc` file, the same as h has, instead of passing args to it on the command line.

`requirements-dev.txt` is removed as its no longer needed. There weren't actually any "dev" (as in running the dev server) requirements in here, they were all requirements for running the tests and linter, and those requirements are listed in `tox.ini` instead now.

```shellsession
$ make help
make help              Show this help message
make dev               Run the app in the development server
make lint              Run the code linter(s) and print any warnings
make test              Run the unit tests
make coverage          Print the unit test coverage report
make codecov           Upload the coverage report to codecov.io
make docstrings        View all the docstrings locally as HTML
make checkdocstrings   Crash if building the docstrings fails
make docker            Make the app's Docker image
make clean             Delete development artefacts (cached files, 
                       dependencies, etc)
```

Note there's no `make shell` for bouncer yet. Bouncer works slightly differently than both h and lms, so the approaches to doing `make shell` in either h or lms don't apply directly to bouncer.