### PR TITLE
Upgrade to Python 3.6 and Alpine Linux 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language:
   - python
 python:
-  - "3.5"
+  - "3.6"
 env:
   - NODE_VERSION="6.9"
 cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM gliderlabs/alpine:3.4
+FROM gliderlabs/alpine:3.8
 MAINTAINER Hypothes.is Project and contributors
 
 # Install system build and runtime dependencies.
-RUN apk-install ca-certificates collectd curl nodejs python3 supervisor
+RUN apk-install ca-certificates collectd curl nodejs nodejs-npm python3 supervisor
 
 # Create the bouncer user, group, home directory and package directory.
 RUN addgroup -S bouncer \
@@ -12,8 +12,7 @@ WORKDIR /var/lib/bouncer
 # Copy packaging
 COPY README.rst package.json requirements.txt ./
 
-RUN npm install --production \
-  && npm cache clean
+RUN npm install --production
 
 RUN pip3 install --no-cache-dir -U pip \
   && pip3 install --no-cache-dir -r requirements.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ node {
     stage('test') {
         testApp(image: img, runArgs: '-u root') {
             sh 'pip install -q tox tox-pip-extensions'
-            sh 'cd /var/lib/bouncer && tox -e py35-tests'
+            sh 'cd /var/lib/bouncer && tox -e py36-tests'
         }
     }
 

--- a/Makefile
+++ b/Makefile
@@ -17,33 +17,33 @@ help:
 
 .PHONY: dev
 dev: node_modules/.uptodate
-	tox -e py35-dev
+	tox -e py36-dev
 
 .PHONY: lint
 lint:
-	tox -e py35-lint
+	tox -e py36-lint
 	./node_modules/.bin/eslint bouncer/scripts
 
 .PHONY: test
 test: node_modules/.uptodate
-	tox -e py35-tests
+	tox -e py36-tests
 	./node_modules/karma/bin/karma start karma.config.js
 
 .PHONY: coverage
 coverage:
-	tox -e py35-coverage
+	tox -e py36-coverage
 
 .PHONY: codecov
 codecov:
-	tox -e py35-codecov
+	tox -e py36-codecov
 
 .PHONY: docstrings
 docstrings:
-	tox -e py35-docstrings
+	tox -e py36-docstrings
 
 .PHONY: checkdocstrings
 checkdocstrings:
-	tox -e py35-checkdocstrings
+	tox -e py36-checkdocstrings
 
 .PHONY: docker
 docker:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ dev: node_modules/.uptodate
 	tox -e py36-dev
 
 .PHONY: lint
-lint:
+lint: node_modules/.uptodate
 	tox -e py36-lint
 	./node_modules/.bin/eslint bouncer/scripts
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35-tests
+envlist = py36-tests
 skipsdist = true
 requires = tox-pip-extensions
 tox_pip_extensions_ext_venv_update = true


### PR DESCRIPTION
The Alpine upgrade is needed for Python 3.6, which was added in Alpine
3.6: https://alpinelinux.org/posts/Alpine-3.6.0-released.html