### PR TITLE
Use the official Alpine Linux base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM gliderlabs/alpine:3.8
+FROM alpine:3.8
 MAINTAINER Hypothes.is Project and contributors
 
 # Install system build and runtime dependencies.
-RUN apk-install ca-certificates collectd curl nodejs nodejs-npm python3 supervisor
+RUN apk add --no-cache \
+  ca-certificates \
+  collectd \
+  curl \
+  nodejs \
+  nodejs-npm \
+  python3 \
+  supervisor
 
 # Create the bouncer user, group, home directory and package directory.
 RUN addgroup -S bouncer \


### PR DESCRIPTION
This works around a build failure with the gliderlabs/alpine image [1]
and matches the Docker image source we use for h. This change is also
recommended by Glider Labs [2] who maintain both images.

The resulting image is slightly larger (167MB vs 160MB for latest
released image) but there is plenty of room to reduce the image size in other
ways.

[1] https://github.com/gliderlabs/docker-alpine/issues/464
[2] https://github.com/gliderlabs/docker-alpine/blob/71099f56701722443807578f1771b07670399c46/docs/build.md#differences