### PR TITLE
Add missing collectd-disk plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Hypothes.is Project and contributors
 RUN apk add --no-cache \
   ca-certificates \
   collectd \
+  collectd-disk \
   curl \
   nodejs \
   nodejs-npm \


### PR DESCRIPTION
collectd was failing to start in an endless loop because the collectd disk
plugin was missing.