### PR TITLE
Pin Docker base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.9.2
 MAINTAINER Hypothes.is Project and contributors
 
 # Install system build and runtime dependencies.


### PR DESCRIPTION
To the latest version. This is to allow Dependabot's Docker support to
work.