### PR TITLE
Add the ability to focus a group via querystring parameter

### DIFF
--- a/tests/bouncer/views_test.py
+++ b/tests/bouncer/views_test.py
@@ -219,6 +219,31 @@ class TestGotoUrlController(object):
         assert data["viaUrl"].endswith(expected_frag)
         assert data["extensionUrl"].endswith(expected_frag)
 
+    def test_it_sets_group_in_fragment(self):
+        request = mock_request()
+        request.GET["url"] = "https://example.com/article.html"
+        request.GET["group"] = "jj333e"
+
+        ctx = views.goto_url(request)
+
+        data = json.loads(ctx["data"])
+        expected_frag = "#annotations:group:jj333e"
+        assert data["viaUrl"].endswith(expected_frag)
+        assert data["extensionUrl"].endswith(expected_frag)
+
+    def test_it_sets_group_in_fragment_if_both_group_and_query_present(self):
+        request = mock_request()
+        request.GET["url"] = "https://example.com/article.html"
+        request.GET["q"] = "findme"
+        request.GET["group"] = "jj333e"
+
+        ctx = views.goto_url(request)
+
+        data = json.loads(ctx["data"])
+        expected_frag = "#annotations:group:jj333e"
+        assert data["viaUrl"].endswith(expected_frag)
+        assert data["extensionUrl"].endswith(expected_frag)
+
     def test_it_rejects_invalid_or_missing_urls(self):
         invalid_urls = [
             None,


### PR DESCRIPTION
Part of https://github.com/hypothesis/product-backlog/issues/864

For the Community Groups project, we need to be able to
generate bouncer links for a URL that automatically
focus a specific group (by group pubid) in the client
layer.

The client has been updated to understand an
extended fragment syntax (`#annotations:group:{pubid}`).
This adds the logic such that bouncer can accept a
`group` query parameter on the `/go` route and
generate a redirect with the correct fragment
syntax for focusing a group.

I clarified a few comments while in there, but otherwise didn't mess with stuff too much.