### PR TITLE
Show lines missing coverage, in coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,5 +40,5 @@ commands =
     docstrings: sphinx-autobuild -BqT -z bouncer -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     checkdocstrings: sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     coverage: -coverage combine
-    coverage: coverage report
+    coverage: coverage report --show-missing
     codecov: codecov


### PR DESCRIPTION
When a file doesn't have 100% test coverage show the line numbers that aren't covered in the coverage report that `make coverage` prints out.