### PR TITLE
Set default envvars in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,6 @@ installation process:
 
     cd bouncer
 
-### Set the environment variables
-
-Set these environment variables in your shell (see
-[Configuration](#configuration) below for documentation of all bouncer's
-environment variables and what they do):
-
-    export DEBUG=yes
-    export HYPOTHESIS_AUTHORITY=localhost
-    export HYPOTHESIS_URL="http://localhost:5000"
-
 ### Start the development server
 
     make dev

--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,13 @@ tox_pyenv_fallback = false
 
 [testenv]
 skip_install = true
+setenv =
+    dev: DEBUG = {env:DEBUG:yes}
+    dev: HYPOTHESIS_AUTHORITY = {env:HYPOTHESIS_AUTHORITY:localhost}
+    dev: HYPOTHESIS_URL = {env:HYPOTHESIS_URL:http://localhost:5000}
+    dev: VIA_BASE_URL = {env:VIA_BASE_URL:http://localhost:9080}
 passenv =
     dev: CHROME_EXTENSION_ID
-    dev: DEBUG
-    dev: HYPOTHESIS_AUTHORITY
-    dev: HYPOTHESIS_URL
     dev: SENTRY_DSN
 deps =
     tests: coverage


### PR DESCRIPTION
Set default values for environment variables in dev, to get bouncer working with local h and via.

Bouncer doesn't have a DB, and doesn't have any sensitive envvars that need to be set, so there's no need for bouncer to use the devdata repo. It also doesn't have a config file! So use `tox.ini` to set envvars in dev only.