### PR TITLE
Moving the pip-compile to tox and it's own env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ checkdocstrings: python
 
 .PHONY: pip-compile
 pip-compile: python
-	tox -q -e py36-dev -- pip-compile --output-file requirements.txt requirements.in
+	tox -q -e py36-pip-compile
 
 .PHONY: docker
 docker:

--- a/tox.ini
+++ b/tox.ini
@@ -36,10 +36,10 @@ deps =
     codecov: codecov
     docstrings: sphinx-autobuild
     {docstrings,checkdocstrings}: sphinx
-    dev: pip-tools
     dev: ipython
     dev: ipdb
     -r requirements.txt
+    pip-compile: pip-tools
 whitelist_externals =
     dev: gunicorn
 commands =
@@ -54,3 +54,4 @@ commands =
     coverage: -coverage combine
     coverage: coverage report --show-missing
     codecov: codecov
+    pip-compile: pip-compile


### PR DESCRIPTION
Moving pip-compile command out of Make and the dev requirements to be a separate tox command. This means the dev env is very slightly smaller, the compile env is much smaller and we are following the more layered approach (make on tox, not instead).