### PR TITLE
Remove codecov and add a coverage minimum value

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,5 @@ source =
 
 [report]
 show_missing = True
+precision = 2
+fail_under = 90.38

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
   include:
     - name: "Test"
       script: make test
-      after_success: make coverage codecov
+      after_success: make coverage
     - name: "Lint"
       script: make lint
     - name: "Check formatting"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ help:
 	@echo "make checkformatting   Crash if the code isn't correctly formatted"
 	@echo "make test              Run the unit tests"
 	@echo "make coverage          Print the unit test coverage report"
-	@echo "make codecov           Upload the coverage report to codecov.io"
 	@echo "make docstrings        View all the docstrings locally as HTML"
 	@echo "make checkdocstrings   Crash if building the docstrings fails"
 	@echo "make pip-compile       Compile requirements.in to requirements.txt"
@@ -42,10 +41,6 @@ test: node_modules/.uptodate python
 .PHONY: coverage
 coverage: python
 	tox -q -e py36-coverage
-
-.PHONY: codecov
-codecov: python
-	tox -q -e py36-codecov
 
 .PHONY: docstrings
 docstrings: python

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/hypothesis/bouncer.svg?branch=master)](https://travis-ci.org/hypothesis/bouncer)
-[![codecov](https://codecov.io/gh/hypothesis/bouncer/branch/master/graph/badge.svg)](https://codecov.io/gh/hypothesis/bouncer)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 Hypothesis Direct-Link Bouncer Service

--- a/tox.ini
+++ b/tox.ini
@@ -55,5 +55,5 @@ commands =
     docstrings: sphinx-autobuild -BqT -z bouncer -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     checkdocstrings: sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     coverage: -coverage combine
-    coverage: coverage report --show-missing
+    coverage: coverage report
     pip-compile: pip-compile {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,6 @@ deps =
     {format,checkformatting}: black
     {format,checkformatting}: isort
     coverage: coverage
-    codecov: codecov
     docstrings: sphinx-autobuild
     {docstrings,checkdocstrings}: sphinx
     dev: ipython
@@ -57,5 +56,4 @@ commands =
     checkdocstrings: sphinx-build -qTn -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml
     coverage: -coverage combine
     coverage: coverage report --show-missing
-    codecov: codecov
     pip-compile: pip-compile {posargs}


### PR DESCRIPTION
Much like we did in LMS, removing the optional information of Codecov for a hard limit which must be met to pass the build.