### PR TITLE
Re-compile requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@
 #
 #    pip-compile
 #
-certifi==2019.11.28       # via -r requirements.in (line 1), requests
+certifi==2019.11.28       # via -r requirements.in, requests
 chardet==3.0.4            # via requests
-elasticsearch==6.3.1      # via -r requirements.in (line 2)
-gunicorn==20.0.4          # via -r requirements.in (line 3)
+elasticsearch==6.3.1      # via -r requirements.in
+gunicorn==20.0.4          # via -r requirements.in
 hupper==1.10.2            # via pyramid
 idna==2.9                 # via requests
 jinja2==2.11.1            # via pyramid-jinja2
@@ -15,12 +15,12 @@ markupsafe==1.1.1         # via jinja2, pyramid-jinja2
 pastedeploy==2.1.0        # via plaster-pastedeploy
 plaster-pastedeploy==0.7  # via pyramid
 plaster==1.0              # via plaster-pastedeploy, pyramid
-pyramid-jinja2==2.8       # via -r requirements.in (line 5)
-pyramid==1.10.4           # via -r requirements.in (line 4), pyramid-jinja2
-raven==6.10.0             # via -r requirements.in (line 8)
-requests-aws4auth==0.9    # via -r requirements.in (line 7)
-requests==2.23.0          # via -r requirements.in (line 6), requests-aws4auth
-statsd==3.3.0             # via -r requirements.in (line 9)
+pyramid-jinja2==2.8       # via -r requirements.in
+pyramid==1.10.4           # via -r requirements.in, pyramid-jinja2
+raven==6.10.0             # via -r requirements.in
+requests-aws4auth==0.9    # via -r requirements.in
+requests==2.23.0          # via -r requirements.in, requests-aws4auth
+statsd==3.3.0             # via -r requirements.in
 translationstring==1.3    # via pyramid
 urllib3==1.25.8           # via elasticsearch, requests
 venusian==3.0.0           # via pyramid


### PR DESCRIPTION
Re-run `make pip-compile` to recreate the requirements.txt file. This
doesn't change any of the requirements or their versions. It's just that
pip-tools (which `make pip-compile` uses) seems to have changed how it
"annotates" the lines in requirements.txt. So I'm just updating
requirements.txt with the new-style annotations.