### PR TITLE
Fix isort (make format and make checkformatting)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,9 +47,9 @@ commands =
     dev: {posargs:gunicorn --reload "bouncer.app:app()"}
     lint: flake8 .
     format: black bouncer tests
-    format: isort --recursive --quiet --atomic bouncer tests
+    format: isort --quiet --atomic bouncer tests
     checkformatting: black --check bouncer tests
-    checkformatting: isort --recursive --quiet --check-only bouncer tests
+    checkformatting: isort --quiet --check-only bouncer tests
     tests: coverage run -m pytest {posargs:tests/bouncer/}
     {docstrings,checkdocstrings}: sphinx-apidoc -ePMF -a -H "Dooccsstrinngs!!" --ext-intersphinx --ext-todo --ext-viewcode -o {envtmpdir}/rst .
     docstrings: sphinx-autobuild -BqT -z bouncer -z tests -b dirhtml {envtmpdir}/rst {envtmpdir}/dirhtml


### PR DESCRIPTION
isort 5.0 removed the `--recursive` option, it's now just always
recursive:

https://github.com/timothycrosley/isort/blob/develop/CHANGELOG.md#500-penny---july-4-2020