### PR TITLE
Remove requests-aws4auth dependency

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,8 +30,7 @@ pygments==2.7.1           # via ipython
 pyramid-jinja2==2.8       # via -r requirements/requirements.txt
 pyramid==1.10.4           # via -r requirements/requirements.txt, pyramid-jinja2
 raven==6.10.0             # via -r requirements/requirements.txt
-requests-aws4auth==1.0    # via -r requirements/requirements.txt
-requests==2.24.0          # via -r requirements/requirements.txt, requests-aws4auth
+requests==2.24.0          # via -r requirements/requirements.txt
 six==1.15.0               # via traitlets
 traitlets==4.3.3          # via ipython
 translationstring==1.4    # via -r requirements/requirements.txt, pyramid

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,5 +4,4 @@ gunicorn
 pyramid
 pyramid-jinja2
 requests
-requests-aws4auth
 raven

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,8 +18,7 @@ plaster==1.0              # via plaster-pastedeploy, pyramid
 pyramid-jinja2==2.8       # via -r requirements/requirements.in
 pyramid==1.10.4           # via -r requirements/requirements.in, pyramid-jinja2
 raven==6.10.0             # via -r requirements/requirements.in
-requests-aws4auth==1.0    # via -r requirements/requirements.in
-requests==2.24.0          # via -r requirements/requirements.in, requests-aws4auth
+requests==2.24.0          # via -r requirements/requirements.in
 translationstring==1.4    # via pyramid
 urllib3==1.25.10          # via elasticsearch, requests
 venusian==3.0.0           # via pyramid

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -31,8 +31,7 @@ pyramid==1.10.4           # via -r requirements/requirements.txt, pyramid-jinja2
 pytest==6.1.0             # via -r requirements/tests.in
 python-dateutil==2.8.1    # via faker
 raven==6.10.0             # via -r requirements/requirements.txt
-requests-aws4auth==1.0    # via -r requirements/requirements.txt
-requests==2.24.0          # via -r requirements/requirements.txt, requests-aws4auth
+requests==2.24.0          # via -r requirements/requirements.txt
 six==1.15.0               # via packaging, python-dateutil
 text-unidecode==1.3       # via faker
 toml==0.10.1              # via pytest


### PR DESCRIPTION
Usage of requests-aws4auth was removed in 4ef03da532fb255358f1bf1cfd8dc26127a2e612
after we switched over to a new Elasticsearch instance which runs inside
our VPC with access controlled via security groups.