### PR TITLE
Do not embed client on docdrop.org

### DIFF
--- a/bouncer/embed_detector.py
+++ b/bouncer/embed_detector.py
@@ -17,6 +17,9 @@ PATTERNS = [
     # American Psychological Organization.
     "psycnet.apa.org/fulltext/*",
     "awspntest.apa.org/fulltext/*",
+    # docdrop.org document hosting.
+    # See https://github.com/hypothesis/bouncer/issues/389.
+    "docdrop.org/*",
 ]
 
 COMPILED_PATTERNS = [re.compile(fnmatch.translate(pat)) for pat in PATTERNS]

--- a/tests/bouncer/embed_detector_test.py
+++ b/tests/bouncer/embed_detector_test.py
@@ -16,6 +16,9 @@ class TestUrlEmbedsClient:
             # Matching URLs with ignored query string / fragment.
             "http://web.hypothes.is/blog/article.foo?ignore_me=1",
             "http://web.hypothes.is/blog/article.foo#ignoreme",
+            # Example matching URLs for various sites on the list.
+            "https://docdrop.org/pdf/1Vsd26C0KuMw4Mj1WEBjBz1T8G75vIhWx-gaQEE.pdf/",
+            "https://docdrop.org/video/AJXGJYl0wJc/",
         ],
     )
     def test_returns_true_for_matching_url(self, url):


### PR DESCRIPTION
docdrop.org is a site that hosts various kinds of document (PDFs, video
transcripts and more) with Hypothesis already embedded.

Fixes #389