### PR TITLE
Make the status endpoint consistent with other apps

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,4 +8,4 @@ source =
 [report]
 show_missing = True
 precision = 2
-fail_under = 96.64
+fail_under = 96.63

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -6,7 +6,6 @@ from elasticsearch import exceptions
 from pyramid import httpexceptions, i18n, view
 from pyramid.httpexceptions import HTTPNoContent
 
-from bouncer import __version__ as bouncer_version
 from bouncer import util
 from bouncer.embed_detector import url_embeds_client
 
@@ -236,7 +235,7 @@ def healthcheck(request):
     if status not in ("yellow", "green"):
         raise FailedHealthcheck("cluster status was {!r}".format(status))
 
-    return {"status": "ok", "version": bouncer_version}
+    return {"status": "okay"}
 
 
 def _is_valid_http_url(url):

--- a/tests/functional/views/healthcheck_test.py
+++ b/tests/functional/views/healthcheck_test.py
@@ -1,7 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-from h_matchers import Any
 
 
 class TestHealthcheck:
@@ -9,7 +8,7 @@ class TestHealthcheck:
         response = app.get("/_status", status=200)
 
         assert response.content_type == "application/json"
-        assert response.json == {"status": "ok", "version": Any.string()}
+        assert response.json == {"status": "okay"}
         assert (
             response.headers["Cache-Control"]
             == "max-age=0, must-revalidate, no-cache, no-store"

--- a/tests/unit/bouncer/views_test.py
+++ b/tests/unit/bouncer/views_test.py
@@ -295,8 +295,7 @@ class TestHealthcheck(object):
 
         result = views.healthcheck(request)
 
-        assert "status" in result
-        assert result["status"] == "ok"
+        assert result == {"status": "okay"}
 
     def test_failed_es_request(self):
         request = mock_request()


### PR DESCRIPTION
Every other app uses "okay" not "ok". This will allow Bouncer's Pingdom alarms to be the same as those for other apps.

It wouldn't do any harm to leave the version number in the status endpoint, but I'm not sure it has much utility and none of our other apps have it.