### PR TITLE
Replace `tox-pip-extensions` with `tox-pip-sync`

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,7 +35,7 @@ ipdb==0.13.7
     # via -r requirements/dev.in
 ipython-genutils==0.2.0
     # via traitlets
-ipython==7.22.0
+ipython==7.23.0
     # via
     #   -r requirements/dev.in
     #   ipdb
@@ -50,6 +50,8 @@ markupsafe==1.1.1
     #   -r requirements/requirements.txt
     #   jinja2
     #   pyramid-jinja2
+matplotlib-inline==0.1.2
+    # via ipython
 parso==0.8.2
     # via jedi
 pastedeploy==2.1.0
@@ -73,7 +75,7 @@ prompt-toolkit==3.0.18
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
-pygments==2.8.1
+pygments==2.9.0
     # via ipython
 pyramid-jinja2==2.8
     # via -r requirements/requirements.txt
@@ -91,7 +93,9 @@ sentry-sdk==1.0.0
 toml==0.10.2
     # via ipdb
 traitlets==5.0.5
-    # via ipython
+    # via
+    #   ipython
+    #   matplotlib-inline
 translationstring==1.4
     # via
     #   -r requirements/requirements.txt

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements/tests.in
 #
-attrs==20.2.0
+attrs==20.3.0
     # via pytest
 certifi==2020.12.5
     # via
@@ -21,7 +21,7 @@ elasticsearch==6.3.1
     # via -r requirements/requirements.txt
 factory-boy==3.2.0
     # via -r requirements/tests.in
-faker==4.1.3
+faker==8.1.2
     # via factory-boy
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
@@ -35,7 +35,7 @@ idna==2.10
     # via
     #   -r requirements/requirements.txt
     #   requests
-iniconfig==1.0.1
+iniconfig==1.1.1
     # via pytest
 jinja2==2.11.3
     # via
@@ -48,7 +48,7 @@ markupsafe==1.1.1
     #   pyramid-jinja2
 mock==4.0.3
     # via -r requirements/tests.in
-packaging==20.4
+packaging==20.9
     # via pytest
 pastedeploy==2.1.0
     # via
@@ -87,12 +87,10 @@ sentry-sdk==1.0.0
     #   -r requirements/requirements.txt
     #   h-pyramid-sentry
 six==1.15.0
-    # via
-    #   packaging
-    #   python-dateutil
+    # via python-dateutil
 text-unidecode==1.3
     # via faker
-toml==0.10.1
+toml==0.10.2
     # via pytest
 translationstring==1.4
     # via

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,9 @@ envlist = tests
 skipsdist = true
 minversion = 3.8.0
 requires =
-    tox-pip-extensions
+    tox-pip-sync
     tox-pyenv
     tox-run-command
-tox_pip_extensions_ext_venv_update = true
 tox_pyenv_fallback = false
 
 [testenv]


### PR DESCRIPTION
For: https://github.com/hypothesis/tox-pip-sync/issues/11

This also recompiles the dependencies afterward using the technique I've been using on the projects done later in case any changes are found. 

This process is to:

 * `rm requirements/*.txt`
 * `git checkout/requirements.txt` - To preserve the set in live
 * `hdev requirements`