### PR TITLE
Update port for local Via service

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ setenv =
     dev: DEBUG = {env:DEBUG:yes}
     dev: HYPOTHESIS_AUTHORITY = {env:HYPOTHESIS_AUTHORITY:localhost}
     dev: HYPOTHESIS_URL = {env:HYPOTHESIS_URL:http://localhost:5000}
-    dev: VIA_BASE_URL = {env:VIA_BASE_URL:http://localhost:9080}
+    dev: VIA_BASE_URL = {env:VIA_BASE_URL:http://localhost:9083}
 passenv =
     HOME
     EXTRA_DEPS


### PR DESCRIPTION
The new "Via 3" version of Via uses 9083 as the development port.