### PR TITLE
Delete CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,1 +1,0 @@
-For now, see the `hypothesis/h contributing guide <https://github.com/hypothesis/h/blob/master/CONTRIBUTING.rst>`_.


### PR DESCRIPTION
If we want a CONTRIBUTING.md I think we should add one to https://github.com/hypothesis/.github where it'll apply to all Hypothesis repos. For now I'm just proposing that we remove this file because I don't think its contents are accurate or up to date