### PR TITLE
Fix GitHub environment names and URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,33 +15,38 @@ jobs:
     uses: ./.github/workflows/continuous-integration.yml
     name: continuous integration
 
-  create-image:
+  Docker_Hub:
+    name: Docker Hub
     needs: continuous-integration
     uses: hypothesis/workflows/.github/workflows/dockerhub.yml@main
     with:
       Application: ${{ github.event.repository.name }}
     secrets: inherit
 
-  qa-us-west-1:
-    needs: create-image
+  QA:
+    needs: Docker_Hub
     name: ${{ github.event.repository.name }}
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
-      Environment: qa
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: QA
+      github_environment_url: https://qa.hyp.is/
+      aws_region: us-west-1
+      elasticbeanstalk_application: bouncer
+      elasticbeanstalk_environment: qa
+      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
     secrets: inherit
 
-  prod-us-west-1:
-    needs: [create-image, qa-us-west-1]
+  Production:
+    needs: [Docker_Hub, QA]
     name: ${{ github.event.repository.name }}
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
-      Environment: prod
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: Production
+      github_environment_url: https://hyp.is/
+      aws_region: us-west-1
+      elasticbeanstalk_application: bouncer
+      elasticbeanstalk_environment: prod
+      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
     secrets: inherit


### PR DESCRIPTION
Change from the `eb-update.yml` workflow to the new `deploy.yml` workflow and
use a separately nicely-named GitHub environment with a URL for each Elastic
Beanstalk environment.

Fixes https://github.com/hypothesis/bouncer/issues/567
