### PR TITLE
Change to more helpful GitHub environment URLs

### DIFF
--- a/.cookiecutter/includes/.github/workflows/environments.json
+++ b/.cookiecutter/includes/.github/workflows/environments.json
@@ -1,7 +1,7 @@
 {
   "qa": {
     "github_environment_name": "QA",
-    "github_environment_url": "https://qa.hyp.is/",
+    "github_environment_url": "https://qa.hyp.is/FiqzonGfEe2o-AfEssZXnw/en.wikipedia.org/wiki/Wikipedia:Terminal_Event_Management_Policy",
     "aws_region": "us-west-1",
     "elasticbeanstalk_application": "bouncer",
     "elasticbeanstalk_environment": "qa"
@@ -9,7 +9,7 @@
   "production": {
     "needs": ["qa"],
     "github_environment_name": "Production",
-    "github_environment_url": "https://hyp.is/",
+    "github_environment_url": "https://hyp.is/FiqzonGfEe2o-AfEssZXnw/en.wikipedia.org/wiki/Wikipedia:Terminal_Event_Management_Policy",
     "aws_region": "us-west-1",
     "elasticbeanstalk_application": "bouncer",
     "elasticbeanstalk_environment": "prod"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: QA
-      github_environment_url: https://qa.hyp.is/
+      github_environment_url: https://qa.hyp.is/FiqzonGfEe2o-AfEssZXnw/en.wikipedia.org/wiki/Wikipedia:Terminal_Event_Management_Policy
       aws_region: us-west-1
       elasticbeanstalk_application: bouncer
       elasticbeanstalk_environment: qa
@@ -38,7 +38,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: Production
-      github_environment_url: https://hyp.is/
+      github_environment_url: https://hyp.is/FiqzonGfEe2o-AfEssZXnw/en.wikipedia.org/wiki/Wikipedia:Terminal_Event_Management_Policy
       aws_region: us-west-1
       elasticbeanstalk_application: bouncer
       elasticbeanstalk_environment: prod

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -19,7 +19,7 @@ jobs:
     with:
       operation: redeploy
       github_environment_name: QA
-      github_environment_url: https://qa.hyp.is/
+      github_environment_url: https://qa.hyp.is/FiqzonGfEe2o-AfEssZXnw/en.wikipedia.org/wiki/Wikipedia:Terminal_Event_Management_Policy
       aws_region: us-west-1
       elasticbeanstalk_application: bouncer
       elasticbeanstalk_environment: qa
@@ -31,7 +31,7 @@ jobs:
     with:
       operation: redeploy
       github_environment_name: Production
-      github_environment_url: https://hyp.is/
+      github_environment_url: https://hyp.is/FiqzonGfEe2o-AfEssZXnw/en.wikipedia.org/wiki/Wikipedia:Terminal_Event_Management_Policy
       aws_region: us-west-1
       elasticbeanstalk_application: bouncer
       elasticbeanstalk_environment: prod


### PR DESCRIPTION
Change the GitHub environment URLs to Bouncer links to a test annotation. These links can actually be clicked on to do a basic test of Bouncer.
