### PR TITLE
"semanticscholar.org" => "www.semanticscholar.org"

### DIFF
--- a/bouncer/embed_detector.py
+++ b/bouncer/embed_detector.py
@@ -18,7 +18,7 @@ PATTERNS = [
     # Publisher partners
     "psycnet.apa.org/fulltext/*",
     "awspntest.apa.org/fulltext/*",
-    "semanticscholar.org/reader/*",  # See https://hypothes-is.slack.com/archives/C04F8GLTT7U/p1674065065018549
+    "www.semanticscholar.org/reader/*",  # See https://hypothes-is.slack.com/archives/C04F8GLTT7U/p1674065065018549
 ]
 
 COMPILED_PATTERNS = [re.compile(fnmatch.translate(pat)) for pat in PATTERNS]

--- a/tests/unit/bouncer/embed_detector_test.py
+++ b/tests/unit/bouncer/embed_detector_test.py
@@ -19,6 +19,7 @@ class TestUrlEmbedsClient:
             # Example matching URLs for various sites on the list.
             "https://docdrop.org/pdf/1Vsd26C0KuMw4Mj1WEBjBz1T8G75vIhWx-gaQEE.pdf/",
             "https://docdrop.org/video/AJXGJYl0wJc/",
+            "https://www.semanticscholar.org/reader/5e331bf7887e2e634bf5b12788849d2d2b74bc7f",
         ],
     )
     def test_returns_true_for_matching_url(self, url):


### PR DESCRIPTION
I added the exact URL pattern that we were asked to add, but the reader is actually hosted at "www.semanticscholar.org" and Bouncer's matching does not currently ignore "www." as we do in some other places.