### PR TITLE
Update all instances of actions/checkout and actions/cache to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup python
         uses: actions/setup-python@v2
@@ -32,7 +32,7 @@ jobs:
         id: list-python-versions
         run: |
           pip install hdev
-          echo "::set-output name=python_headline_version::`hdev python_version --style plain --first`"
+          echo "python_headline_version=`hdev python_version --style plain --first`" >> $GITHUB_OUTPUT
 
   backend:
     name: Backend
@@ -54,10 +54,10 @@ jobs:
       run: python -m pip install 'tox<4'
 
     - name: Checkout git repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Cache the .tox dir
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: .tox
         key: ${{ runner.os }}-tox-${{ hashFiles('tox.ini', 'requirements*', 'setup.py', 'setup.cfg') }}
@@ -73,10 +73,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Cache the node_modules dir
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
This pull request addresses a couple of warnings printed in our workflows, by updating to the latest instances of some actions and changing how we pass info between jobs via output.