### PR TITLE
Support setting a different extension ID per authority

### DIFF
--- a/bouncer/app.py
+++ b/bouncer/app.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pyramid.config
@@ -20,10 +21,18 @@ def settings():
     else:
         debug = False
 
+    extension_ids = os.environ.get(
+        "CHROME_EXTENSION_ID", "bjfhmglciegochdpefhhlphglcehbmek"
+    )
+    if extension_ids.strip().startswith("{"):
+        extension_ids = json.loads(extension_ids)
+        if not extension_ids.get("default"):
+            raise Exception('CHROME_EXTENSION_ID map must have a "default" key')
+    else:
+        extension_ids = {"default": extension_ids}
+
     result = {
-        "chrome_extension_id": os.environ.get(
-            "CHROME_EXTENSION_ID", "bjfhmglciegochdpefhhlphglcehbmek"
-        ),
+        "chrome_extension_id": extension_ids,
         "debug": debug,
         "elasticsearch_index": os.environ.get("ELASTICSEARCH_INDEX", "hypothesis"),
         "hypothesis_authority": os.environ.get("HYPOTHESIS_AUTHORITY", "localhost"),

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -80,12 +80,15 @@ class AnnotationController(object):
 
         title = util.get_boilerplate_quote(document_uri)
 
+        default_extension = settings["chrome_extension_id"]["default"]
+        extension_id = settings["chrome_extension_id"].get(authority, default_extension)
+
         return {
             "data": json.dumps(
                 {
                     # Warning: variable names change from python_style to
                     # javaScriptStyle here!
-                    "chromeExtensionId": settings["chrome_extension_id"],
+                    "chromeExtensionId": extension_id,
                     "viaUrl": via_url,
                     "extensionUrl": extension_url,
                 }
@@ -164,7 +167,9 @@ def goto_url(request):
     return {
         "data": json.dumps(
             {
-                "chromeExtensionId": settings["chrome_extension_id"],
+                # nb. We always use the default extension ID here, because we
+                # don't have an annotation to determine the authority.
+                "chromeExtensionId": settings["chrome_extension_id"]["default"],
                 "viaUrl": via_url,
                 "extensionUrl": extension_url,
             }

--- a/tests/unit/bouncer/views_test.py
+++ b/tests/unit/bouncer/views_test.py
@@ -62,6 +62,12 @@ class TestAnnotationController(object):
         data = json.loads(template_data["data"])
         assert data["chromeExtensionId"] == "test-extension-id"
 
+    def test_annotation_returns_chrome_extension_id_for_authority(self, parse_document):
+        parse_document.return_value["authority"] = "alt.authority"
+        template_data = views.AnnotationController(mock_request()).annotation()
+        data = json.loads(template_data["data"])
+        assert data["chromeExtensionId"] == "alt-extension-id"
+
     def test_annotation_returns_quote(self):
         template_data = views.AnnotationController(mock_request()).annotation()
         quote = template_data["quote"]
@@ -336,7 +342,10 @@ def parse_document(request):
 def mock_request():
     request = testing.DummyRequest()
     request.registry.settings = {
-        "chrome_extension_id": "test-extension-id",
+        "chrome_extension_id": {
+            "default": "test-extension-id",
+            "alt.authority": "alt-extension-id",
+        },
         "debug": False,
         "elasticsearch_url": "http://localhost:9200",
         "elasticsearch_index": "hypothesis",


### PR DESCRIPTION
Allow the Chrome extension ID to be customized depending on the authority that an annotation is associated with. The extension IDs are specified by setting the `CHROME_EXTENSION_ID` env var to a JSON map of authority to extension ID. The map must contain a "default" field which specifies the extension to use if no other entry matches. The existing syntax of setting `CHROME_EXTENSION_ID` to a single ID string is still supported.

The initial use case for this is to support bouncer links for annotations created using the Hypothesis for Confluence extension. The eventual plan is to fold that integration back into the main extension, so this might be fairly short-lived flexibility.

For example:

```
export CHROME_EXTENSION_ID='{"default":"abc...", "atlassian.hypothes.is": "def..."}'
```