### PR TITLE
Use `WEB_CONCURRENCY` instead of `workers` in dev

### DIFF
--- a/conf/gunicorn-dev.conf.py
+++ b/conf/gunicorn-dev.conf.py
@@ -2,4 +2,3 @@ bind = "0.0.0.0:8000"
 reload = True
 reload_extra_files = "bouncer/templates"
 timeout = 0
-workers = 2

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ setenv =
     dev: HYPOTHESIS_AUTHORITY = {env:HYPOTHESIS_AUTHORITY:localhost}
     dev: HYPOTHESIS_URL = {env:HYPOTHESIS_URL:http://localhost:5000}
     dev: VIA_BASE_URL = {env:VIA_BASE_URL:http://localhost:9083}
+    dev: WEB_CONCURRENCY = {env:WEB_CONCURRENCY:2}
 passenv =
     HOME
     dev: CHROME_EXTENSION_ID


### PR DESCRIPTION
Use the `WEB_CONCURRENCY` envvar in `tox.ini` instead of the `workers`
setting in `gunicorn-dev.conf.py`. This is how it's already done in the
cookiecutter and is how we do it in prod.
