### PR TITLE
Fix docker image after alpine version upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Hypothes.is Project and contributors
 RUN apk add --no-cache \
   curl \
   nodejs \
-  nodejs-npm \
+  npm \
   supervisor
 
 # Create the bouncer user, group, home directory and package directory.


### PR DESCRIPTION
node/npm packages have been renamed


See failure at: https://github.com/hypothesis/bouncer/actions/runs/7569589307/job/20613225326

```
0.590 ERROR: unable to select packages:
61
0.590   nodejs-npm (no such package):
62

```


Missed this locally. Now `make docker` does work.