### PR TITLE
Add Sentry support to the /_status endpoint

### DIFF
--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -5,6 +5,7 @@ import h_pyramid_sentry
 from elasticsearch import exceptions
 from pyramid import httpexceptions, i18n, view
 from pyramid.httpexceptions import HTTPNoContent
+from sentry_sdk import capture_message
 
 from bouncer import util
 from bouncer.embed_detector import url_embeds_client
@@ -239,6 +240,9 @@ def healthcheck(request):
 
     if status not in ("yellow", "green"):
         raise FailedHealthcheck("cluster status was {!r}".format(status))
+
+    if "sentry" in request.params:
+        capture_message("Test message from the healthcheck() view")
 
     return {"status": "okay"}
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ setenv =
     dev: HYPOTHESIS_URL = {env:HYPOTHESIS_URL:http://localhost:5000}
     dev: VIA_BASE_URL = {env:VIA_BASE_URL:http://localhost:9083}
     dev: WEB_CONCURRENCY = {env:WEB_CONCURRENCY:2}
+    dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
 passenv =
     HOME
     dev: CHROME_EXTENSION_ID


### PR DESCRIPTION
Have the `/_status` endpoint send a test message to Sentry if called
with a `?sentry` query param.

This enables testing the Sentry configuration in different environments
(production, staging, etc). Otherwise you'd need to have some way to
make the app crash in order to test it.

`?sentry` does not affect the status endpoint's HTTP return status so it
won't affect Elastic Beanstalk health checking.
