### PR TITLE
Fix jinja2 import after version upgrade

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,4 +8,4 @@ source =
 [report]
 show_missing = True
 precision = 2
-fail_under = 96.63
+fail_under = 100

--- a/bouncer/_version.py
+++ b/bouncer/_version.py
@@ -43,7 +43,7 @@ def git_version():
     return pep440_version(date, ref, dirty)
 
 
-def git_archive_version():
+def git_archive_version():  # pragma: nocover
     ref = VERSION_GIT_REF
     date = datetime.datetime.fromtimestamp(int(VERSION_GIT_DATE))
     return pep440_version(date, ref)
@@ -56,7 +56,7 @@ def pep440_version(date, ref, dirty=False):
     )
 
 
-def get_version():
+def get_version():  # pragma: nocover
     """Fetch the current application version."""
     # First we try to retrieve the current application version from git.
     try:

--- a/bouncer/app.py
+++ b/bouncer/app.py
@@ -4,7 +4,7 @@ import os
 import pyramid.config
 
 
-def settings():
+def settings():  # pragma: nocover
     """
     Return the app's configuration settings as a dict.
 
@@ -16,10 +16,7 @@ def settings():
     if via_base_url.endswith("/"):
         via_base_url = via_base_url[:-1]
 
-    if "DEBUG" in os.environ:
-        debug = True
-    else:
-        debug = False
+    debug = "DEBUG" in os.environ
 
     extension_ids = os.environ.get(
         "CHROME_EXTENSION_ID", "bjfhmglciegochdpefhhlphglcehbmek"
@@ -45,7 +42,7 @@ def settings():
     return result
 
 
-def create_app(_=None, **_settings):
+def create_app(_=None, **_settings):  # pragma: nocover
     """Configure and return the WSGI app."""
     config = pyramid.config.Configurator(settings=settings())
     config.add_static_view(name="static", path="static")

--- a/bouncer/embed_detector.py
+++ b/bouncer/embed_detector.py
@@ -24,7 +24,7 @@ PATTERNS = [
 COMPILED_PATTERNS = [re.compile(fnmatch.translate(pat)) for pat in PATTERNS]
 
 
-def url_embeds_client(url):
+def url_embeds_client(url):  # pragma: nocover
     """
     Test whether ``url`` is known to embed the client.
 

--- a/bouncer/search.py
+++ b/bouncer/search.py
@@ -11,7 +11,7 @@ def get_client(settings):
     return Elasticsearch([host], **kwargs)
 
 
-def includeme(config):
+def includeme(config):  # pragma: nocover
     settings = config.registry.settings
     settings.setdefault("elasticsearch_url", "http://localhost:9200")
 

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -1,6 +1,6 @@
 from urllib import parse
 
-import jinja2
+from markupsafe import Markup
 from pyramid import i18n
 
 _ = i18n.TranslationStringFactory(__package__)
@@ -148,8 +148,8 @@ def get_pretty_url(url):
         return None
 
     pretty_url = parsed_url.netloc[:NETLOC_MAX_LENGTH]
-    if len(parsed_url.netloc) > NETLOC_MAX_LENGTH:  # pragma: nocover
-        pretty_url += jinja2.Markup("&hellip;")
+    if len(parsed_url.netloc) > NETLOC_MAX_LENGTH:
+        pretty_url += Markup("&hellip;")
     return pretty_url
 
 

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -96,7 +96,7 @@ def parse_document(document):
 
     try:
         targets = annotation["target"]
-        if targets:
+        if targets:  # pragma: nocover
             document_uri = targets[0]["source"]
             selectors = targets[0].get("selector", [])
             for selector in selectors:
@@ -113,9 +113,9 @@ def parse_document(document):
     if isinstance(document_uri, str) and document_uri.startswith("urn:x-pdf:"):
         try:
             web_uri = annotation["document"]["web_uri"]
-            if web_uri:
+            if web_uri:  # pragma: nocover
                 document_uri = web_uri
-        except KeyError:
+        except KeyError:  # pragma: nocover
             pass
 
     if document_uri is None:
@@ -148,7 +148,7 @@ def get_pretty_url(url):
         return None
 
     pretty_url = parsed_url.netloc[:NETLOC_MAX_LENGTH]
-    if len(parsed_url.netloc) > NETLOC_MAX_LENGTH:
+    if len(parsed_url.netloc) > NETLOC_MAX_LENGTH:  # pragma: nocover
         pretty_url += jinja2.Markup("&hellip;")
     return pretty_url
 

--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -102,7 +102,7 @@ class AnnotationController(object):
 
 
 @view.view_config(renderer="bouncer:templates/index.html.jinja2", route_name="index")
-def index(request):
+def index(request):  # pragma: nocover
     raise httpexceptions.HTTPFound(location=request.registry.settings["hypothesis_url"])
 
 

--- a/tests/unit/bouncer/util_test.py
+++ b/tests/unit/bouncer/util_test.py
@@ -110,6 +110,12 @@ def test_parse_document_returns_authority(es_annotation_doc):
     assert authority == "hypothes.is"
 
 
+def test_get_pretty_url_for_long_url():
+    long_netloc = "https://www.verylongdomainthatkeepsgoingandgoing.com"
+
+    assert "www.verylongdomainthatkeepsgoi&hellip;" == util.get_pretty_url(long_netloc)
+
+
 @pytest.fixture
 def es_annotation_doc():
     """


### PR DESCRIPTION
Require 100% coverage but mark existings gaps with `nocover` like we did in H. The idea is that any changes to this codebase will require the 100% coverage an ideally the existing gaps will disappear. 


Fix jinja2 issue after the upgrade.