### PR TITLE
Make sentry-sdk a direct requirement

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,7 @@
 certifi
 elasticsearch==6.3.1
 gunicorn
+sentry-sdk
 h-pyramid-sentry
 pyramid
 pyramid-jinja2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -49,7 +49,9 @@ pyramid-jinja2==2.10
 requests==2.31.0
     # via -r requirements/requirements.in
 sentry-sdk==1.39.2
-    # via h-pyramid-sentry
+    # via
+    #   -r requirements/requirements.in
+    #   h-pyramid-sentry
 translationstring==1.4
     # via pyramid
 urllib3==2.1.0


### PR DESCRIPTION
So that Dependabot keeps it up to date.
