### PR TITLE
Replace mapping type with "_doc" when talking to an ES 7 server

### DIFF
--- a/tests/unit/bouncer/views_test.py
+++ b/tests/unit/bouncer/views_test.py
@@ -10,12 +10,20 @@ from bouncer import util, views
 
 @pytest.mark.usefixtures("parse_document")
 class TestAnnotationController(object):
-    def test_annotation_calls_get(self):
+    @pytest.mark.parametrize(
+        "es_version,doc_type",
+        [
+            ("6.2.0", "annotation"),
+            ("7.10.0", "_doc"),
+        ],
+    )
+    def test_annotation_calls_get(self, es_version, doc_type):
         request = mock_request()
+        request.es.info.return_value["version"]["number"] = es_version
         views.AnnotationController(request).annotation()
 
         request.es.get.assert_called_once_with(
-            index="hypothesis", doc_type="annotation", id="AVLlVTs1f9G3pW-EYc6q"
+            index="hypothesis", doc_type=doc_type, id="AVLlVTs1f9G3pW-EYc6q"
         )
 
     def test_annotation_raises_http_not_found_if_annotation_deleted(
@@ -375,6 +383,11 @@ def mock_request():
             "uri": "http://www.example.com/example.html",
             "group": "__world__",
         },
+    }
+    request.es.info.return_value = {
+        "version": {
+            "number": "6.2.0",
+        }
     }
     request.raven = mock.Mock()
     return request


### PR DESCRIPTION
As explained in
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html#_schedule_for_removal_of_mapping_types, the mapping type in request URLs is replaced by the dummy type name "_doc" in Elasticsearch 7, as part of the removal of mapping types.

The endpoint for fetching an annotation changes from:

 ```{es_server}/hypothesis/annotation/{annotation_id}```

To:

```{es_server}/hypothesis/_doc/{annotation_id}```

Fixes https://github.com/hypothesis/bouncer/issues/563.

---

**Testing:**

1. Update h to ES 7 using https://github.com/hypothesis/h/pull/9072
2. Create a shared annotation using the client and copy its bouncer link
3. Visit the bouncer link

On `main`, the bouncer server logs will show a 404 when fetching the annotation from Elasticsearch. On this branch it should work.