### PR TITLE
Redirect user to Via if annotation is a transcript annotation

### DIFF
--- a/bouncer/scripts/redirect.js
+++ b/bouncer/scripts/redirect.js
@@ -81,6 +81,11 @@ export async function redirect(
     return;
   }
 
+  if (settings.alwaysUseVia) {
+    navigateTo(settings.viaUrl);
+    return;
+  }
+
   const chrome = window.chrome;
   if (chrome && chrome.runtime && chrome.runtime.sendMessage) {
     // The user is using Chrome, redirect them to our Chrome extension if they

--- a/bouncer/scripts/test/redirect-test.js
+++ b/bouncer/scripts/test/redirect-test.js
@@ -169,4 +169,14 @@ describe('#redirect', () => {
     assert.isTrue(navigateTo.calledOnce);
     assert.isTrue(navigateTo.calledWithExactly(settings.extensionUrl));
   });
+
+  it('redirects to Via if `alwaysUseVia` is true', () => {
+    settings.alwaysUseVia = true;
+    const navigateTo = sinon.stub();
+
+    redirect(navigateTo, settings);
+
+    assert.isTrue(navigateTo.calledOnce);
+    assert.isTrue(navigateTo.calledWithExactly(settings.viaUrl));
+  });
 });

--- a/bouncer/util.py
+++ b/bouncer/util.py
@@ -92,15 +92,19 @@ def parse_document(document):
     if not text:
         text = ANNOTATION_BOILERPLATE_TEXT
 
+    has_media_time = False
+
     try:
         targets = annotation["target"]
         if targets:  # pragma: nocover
             document_uri = targets[0]["source"]
             selectors = targets[0].get("selector", [])
             for selector in selectors:
-                if selector.get("type") != "TextQuoteSelector":
-                    continue
-                quote = selector.get("exact")
+                match selector.get("type"):
+                    case "TextQuoteSelector":
+                        quote = selector.get("exact")
+                    case "MediaTimeSelector":
+                        has_media_time = True
     except KeyError:
         pass
 
@@ -133,6 +137,7 @@ def parse_document(document):
         "show_metadata": show_metadata,
         "quote": _escape_quotes(quote),
         "text": _escape_quotes(text),
+        "has_media_time": has_media_time,
     }
 
 

--- a/tests/unit/bouncer/util_test.py
+++ b/tests/unit/bouncer/util_test.py
@@ -116,6 +116,21 @@ def test_get_pretty_url_for_long_url():
     assert "www.verylongdomainthatkeepsgoi&hellip;" == util.get_pretty_url(long_netloc)
 
 
+@pytest.mark.parametrize(
+    "selectors,has_media_time",
+    [
+        ([{"type": "MediaTimeSelector", "start": 10, "end": 20}], True),
+        ([{}], False),
+    ],
+)
+def test_parse_document_returns_has_media_time(
+    es_annotation_doc, selectors, has_media_time
+):
+    es_annotation_doc["_source"]["target"][0]["selector"] = selectors
+    parsed = util.parse_document(es_annotation_doc)
+    assert parsed["has_media_time"] == has_media_time
+
+
 @pytest.fixture
 def es_annotation_doc():
     """


### PR DESCRIPTION
When following a bouncer link for an annotation, check if the annotation is a YouTube transcript annotation made using Via. If so, redirect the user to Via even if they have the extension installed.

Via's video player app does not currently record a specific marker indicating that it was used to create the annotation, but it is the only tool that will create an annotation with a `MediaTimeSelector` selector on annotations with document URLs of the form `https://www.youtube.com/watch?v={id}`.

Fixes https://github.com/hypothesis/product-backlog/issues/1604
Fixes https://github.com/hypothesis/bouncer/issues/690