### PR TITLE
Enable Sentry's "releases" feature

### DIFF
--- a/bouncer/app.py
+++ b/bouncer/app.py
@@ -3,6 +3,8 @@ import os
 
 import pyramid.config
 
+from bouncer._version import get_version
+
 
 def settings():  # pragma: nocover
     """
@@ -53,5 +55,21 @@ def create_app(_=None, **_settings):  # pragma: nocover
     }
     config.include("bouncer.search")
     config.include("bouncer.views")
+
+    # Enable Sentry's "Releases" feature, see:
+    # https://docs.sentry.io/platforms/python/configuration/options/#release
+    #
+    # h_pyramid_sentry passes any h_pyramid_sentry.init.* Pyramid settings
+    # through to sentry_sdk.init(), see:
+    # https://github.com/hypothesis/h-pyramid-sentry?tab=readme-ov-file#settings
+    #
+    # For the full list of options that sentry_sdk.init() supports see:
+    # https://docs.sentry.io/platforms/python/configuration/options/
+    config.add_settings(
+        {
+            "h_pyramid_sentry.init.release": get_version(),
+        }
+    )
     config.include("h_pyramid_sentry")
+
     return config.make_wsgi_app()


### PR DESCRIPTION
I'm hoping this is going to get rid of "Discarded session update because
of missing release" error messages that `sentry_sdk` has started logging
in production every few seconds, see:
https://hypothes-is.slack.com/archives/C1MA4E9B9/p1744116427133249

The releases feature is also a useful feature in itself, so it'll be
good to make use of this. I think we may also need to do a little work
on our deployment scripts to enable the full Sentry releases feature
set, see:
https://docs.sentry.io/product/releases/setup/release-automation/github-actions/
