### PR TITLE
Potential fix for code scanning alert no. 3: Reflected server-side cross-site scripting

### DIFF
--- a/bouncer/views.py
+++ b/bouncer/views.py
@@ -166,7 +166,7 @@ def goto_url(request):
     # append our own.
     url = parse.urldefrag(url)[0]
 
-    group = request.params.get("group", "")
+    group = parse.quote(request.params.get("group", ""), safe="")
     query = parse.quote(request.params.get("q", ""))
 
     # Translate any refining querystring parameters into a URL fragment

--- a/tests/unit/bouncer/views_test.py
+++ b/tests/unit/bouncer/views_test.py
@@ -219,6 +219,45 @@ class TestGotoUrlController(object):
         assert data["viaUrl"].endswith(expected_frag)
         assert data["extensionUrl"].endswith(expected_frag)
 
+    def test_it_percent_encodes_group_with_special_characters(self):
+        request = mock_request()
+        request.GET["url"] = "https://example.com/article.html"
+        request.GET["group"] = '<script>alert("xss")</script>'
+
+        ctx = views.goto_url(request)
+
+        data = json.loads(ctx["data"])
+        # The group value must be percent-encoded; raw '<', '>', '"' must not appear
+        assert "<" not in data["viaUrl"]
+        assert "<" not in data["extensionUrl"]
+        expected_frag = "#annotations:group:%3Cscript%3Ealert%28%22xss%22%29%3C%2Fscript%3E"
+        assert data["viaUrl"].endswith(expected_frag)
+        assert data["extensionUrl"].endswith(expected_frag)
+
+    def test_it_percent_encodes_group_with_angle_brackets_and_quotes(self):
+        request = mock_request()
+        request.GET["url"] = "https://example.com/article.html"
+        request.GET["group"] = '<"group">'
+
+        ctx = views.goto_url(request)
+
+        data = json.loads(ctx["data"])
+        expected_frag = "#annotations:group:%3C%22group%22%3E"
+        assert data["viaUrl"].endswith(expected_frag)
+        assert data["extensionUrl"].endswith(expected_frag)
+
+    def test_it_percent_encodes_group_with_ampersand_and_equals(self):
+        request = mock_request()
+        request.GET["url"] = "https://example.com/article.html"
+        request.GET["group"] = "group&id=1"
+
+        ctx = views.goto_url(request)
+
+        data = json.loads(ctx["data"])
+        expected_frag = "#annotations:group:group%26id%3D1"
+        assert data["viaUrl"].endswith(expected_frag)
+        assert data["extensionUrl"].endswith(expected_frag)
+
     def test_it_rejects_invalid_or_missing_urls(self):
         invalid_urls = [
             None,


### PR DESCRIPTION
Potential fix for [https://github.com/hypothesis/bouncer/security/code-scanning/3](https://github.com/hypothesis/bouncer/security/code-scanning/3)

To fix this without changing behavior, normalize/encode `group` before inserting it into `fragment`, the same way `q` is handled. The best minimal fix is to percent-encode `group` using `urllib.parse.quote(..., safe="")` when reading it from `request.params`. This preserves intended semantics (group still passed in fragment) while preventing injection payloads from being reflected as active markup/script.

In `bouncer/views.py`, inside `goto_url`:
- Change the `group` assignment (currently raw `request.params.get("group", "")`) to a quoted value.
- Keep existing logic unchanged otherwise.

No new imports are required because `parse` is already imported from `urllib`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
